### PR TITLE
Disable debug logs by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
       pre.textContent = args.map(a => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
       drawer.appendChild(pre);
     };
+  } else if (drawer) {
+    drawer.classList.add("hidden");
+    drawer.style.display = "none";
   }
 </script>
 

--- a/schema.js
+++ b/schema.js
@@ -1,11 +1,11 @@
 // --- DEBUG LOGGER (utilisé par index.html et app.js)
 export const D = {
-  on: true, // passe à false pour couper le tiroir de logs
-  info:  (...a) => console.info(...a),
-  warn:  (...a) => console.warn(...a),
-  error: (...a) => console.error(...a),
-  group: (...a) => console.group(...a),
-  groupEnd:     () => console.groupEnd(),
+  on: false, // passe à true pour voir le tiroir de logs
+  info:  (...a) => D.on && console.info(...a),
+  warn:  (...a) => D.on && console.warn(...a),
+  error: (...a) => D.on && console.error(...a),
+  group: (...a) => D.on && console.group(...a),
+  groupEnd:     () => D.on && console.groupEnd(),
 };
 // --- Helpers de chemin /u/{uid}/...
 import {


### PR DESCRIPTION
## Summary
- gate the debug logger helpers behind the D.on flag before calling console methods
- disable the debug logger by default to avoid production noise
- ensure the debug drawer stays hidden when logging is turned off

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cffd5a0b9483338a7ff2f46826df33