### PR TITLE
Refine daily and practice submission flows

### DIFF
--- a/goals.js
+++ b/goals.js
@@ -101,6 +101,11 @@ export async function renderGoals(ctx, root){
   window.__ctx = ctx;
   root.innerHTML = "";
   root.append(el("h2",{},"Objectifs"));
+  const bar = el("div",{class:"section-title"},[
+    el("div",{},""), // spacer
+    el("button",{class:"btn small right", onclick:()=>openGoalForm(ctx)}, "+ Nouvel objectif")
+  ]);
+  root.append(bar);
   const qy = query(col(ctx.db, ctx.user.uid, "goals"), orderBy("createdAt","desc"));
   const ss = await getDocs(qy);
   const byT = { weekly:[], monthly:[], yearly:[] };
@@ -162,7 +167,7 @@ async function saveGoalResponse(ctx, goal, value){
     ownerUid: ctx.user.uid, goalId: goal.id, value, temporalUnit: goal.temporalUnit, createdAt: Schema.now()
   };
   const srPrev = await Schema.readSRState(ctx.db, ctx.user.uid, goal.id, "goal_"+goal.temporalUnit);
-  const upd = Schema.nextCooldownAfterAnswer({ ...goal, mode:"daily" }, srPrev, (goal.type==="likert6"?value: (goal.type==="num"?value:"yes")));
+  const upd = Schema.nextCooldownAfterAnswer({ mode: "daily", type: goal.type }, srPrev, value);
   await Schema.upsertSRState(ctx.db, ctx.user.uid, goal.id, "goal_"+goal.temporalUnit, upd);
   await addDoc(col(ctx.db, ctx.user.uid, "goalResponses"), payload);
 }

--- a/index.html
+++ b/index.html
@@ -15,17 +15,6 @@
       --shadow: 0 10px 25px rgba(0,0,0,.25), 0 2px 6px rgba(0,0,0,.2);
     }
 
-    /* tiroir de logs debug */
-    #debug-drawer {
-      position: fixed; right: 10px; bottom: 10px;
-      width: 360px; max-height: 45vh; overflow: auto;
-      background: rgba(8,12,18,.9); border: 1px solid var(--border);
-      border-radius: 12px; padding: 10px;
-      box-shadow: var(--shadow); font-size: 12px;
-      color: #cbd5e1; display: none;
-    }
-    #debug-drawer.visible { display: block }
-    #debug-drawer pre { margin: 0; white-space: pre-wrap }
   </style>
 </head>
 <body class="bg-gradient-to-b from-[#0b0f14] to-[#0e1621] text-gray-200 font-sans min-h-screen">
@@ -53,28 +42,6 @@
     </div>
   </section>
 </main>
-
-<div id="debug-drawer" class="hidden"></div>
-<script type="module">
-  // Si tu ne veux aucun log à l'écran, supprime entièrement ce <script>.
-  // Sinon: mets D.on = true dans schema.js
-  import { D } from "./schema.js";
-  const drawer = document.getElementById("debug-drawer");
-  if (D.on && drawer){
-    drawer.classList.remove("hidden");
-    drawer.style.display = "block";
-    const o = console.info;
-    console.info = (...args) => {
-      o.apply(console, args);
-      const pre = document.createElement("pre");
-      pre.textContent = args.map(a => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
-      drawer.appendChild(pre);
-    };
-  } else if (drawer) {
-    drawer.classList.add("hidden");
-    drawer.style.display = "none";
-  }
-</script>
 
 <script type="module">
   import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";


### PR DESCRIPTION
## Summary
- replace the daily and practice screens with single-submit forms, day filtering, iteration refresh, and mini-history widgets
- centralize spaced-repetition helpers, batch response saving, and mute the in-app logger by default
- expose goal creation from the objectives tab, fix route parsing for day/new query params, and remove the debug drawer

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d017f0ff6483339355ee595f1fd7be