### PR TITLE
Fix routing issues and improve mobile layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,15 @@ function routeTo(hash) {
   // hash like "#/daily", "#/practice?new=1", etc.
   if (!hash) hash = "#/daily";
 
+  // Si l'argument est déjà une URL utilisateur complète, on la prend telle quelle
+  if (/^#\/u\/[^/]+\//.test(hash)) {
+    log("routeTo", { from: location.hash || null, requested: hash, target: hash });
+    ctx.route = hash;
+    window.location.hash = hash;
+    render();
+    return;
+  }
+
   // If we are currently on a user URL, prefix all routes with /u/{uid}/...
   const m = (location.hash || "").match(/^#\/u\/([^/]+)/);
   const base = m ? `#/u/${m[1]}/` : "#/";
@@ -66,6 +75,11 @@ function setActiveNav(sectionKey) {
     const isActive = target === activeTarget;
     btn.setAttribute("aria-current", isActive ? "page" : "false");
   });
+
+  // Cacher Admin si on navigue dans /u/{uid}/...
+  const isUserURL = /^#\/u\/[^/]+/.test(location.hash || ctx.route);
+  const adminBtn = document.querySelector('button[data-route="#/admin"]');
+  if (adminBtn) adminBtn.style.display = isUserURL ? "none" : "";
 }
 
 function parseHash(hashValue) {

--- a/index.html
+++ b/index.html
@@ -45,8 +45,9 @@
     input:focus, textarea:focus, select:focus{ outline:none; border-color:var(--ring); box-shadow:0 0 0 3px var(--accent-50); }
 
     /* Onglets (pills) + état actif coloré */
-    .tabs{ display:flex; gap:.5rem; align-items:center; }
-    .tab{ border:1px solid #E5E7EB; background:#fff; border-radius:999px; padding:.5rem .875rem; font-size:.9rem; display:inline-flex; gap:.5rem; align-items:center; }
+    .tabs{ display:flex; gap:.5rem; align-items:center; overflow-x:auto; flex-wrap:nowrap; -webkit-overflow-scrolling:touch; }
+    .tabs::-webkit-scrollbar{ display:none; }
+    .tab{ border:1px solid #E5E7EB; background:#fff; border-radius:999px; padding:.5rem .875rem; font-size:.9rem; display:inline-flex; gap:.5rem; align-items:center; white-space:nowrap; flex:0 0 auto; }
     .tab[aria-current="page"]{ background:var(--accent-50); border-color:var(--accent-400); color:#0B4B66; }
 
     /* Boutons */
@@ -62,14 +63,24 @@
 
     /* Sidebar cachée par défaut (mode admin != user) */
     #sidebar{ display:none; }
+
+    /* Titre un peu plus petit sur mobile */
+    @media (max-width: 640px){
+      header h1{ font-size:1rem; }
+    }
+
+    /* utilitaire pour masquer la scrollbar (déjà utilisé ci-dessus) */
+    .no-scrollbar::-webkit-scrollbar{ display:none; }
+    .no-scrollbar{ -ms-overflow-style:none; scrollbar-width:none; }
   </style>
 </head>
 <body class="min-h-screen">
   <div class="flex min-h-screen flex-col">
     <header class="border-b border-gray-200 bg-white">
-      <div class="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-4">
-        <h1 class="text-xl font-semibold">Habitudes &amp; Pratique</h1>
-        <nav class="tabs">
+      <div class="mx-auto w-full max-w-5xl px-4 py-4
+            flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 class="text-lg sm:text-xl font-semibold">Habitudes &amp; Pratique</h1>
+        <nav class="tabs w-full sm:w-auto overflow-x-auto no-scrollbar">
           <button class="tab" data-route="#/daily"><span>📅</span><span>Journalier</span></button>
           <button class="tab" data-route="#/practice"><span>⚡</span><span>Pratique</span></button>
           <button class="tab" data-route="#/goals"><span>🎯</span><span>Objectifs</span></button>

--- a/modes.js
+++ b/modes.js
@@ -72,6 +72,10 @@ function navigate(hash) {
   else window.location.hash = hash;
 }
 
+function toAppPath(h) {
+  return h.replace(/^#\/u\/[^/]+\//, "#/");
+}
+
 async function categorySelect(ctx, mode, currentName = "") {
   const cats = await Schema.fetchCategories(ctx.db, ctx.user.uid);
   const names = cats.filter(c => c.mode === mode).map(c => c.name);
@@ -299,9 +303,13 @@ export async function openHistory(ctx, consigne) {
       const formatted = formatValue(consigne.type, r.value);
       const status = dotColor(consigne.type, r.value);
       return `
-    <li class="flex items-center justify-between gap-3 py-2">
-      <span class="text-sm text-[var(--muted)]">${escapeHtml(date)}</span>
-      <span class="flex items-center gap-2 text-sm font-medium">${dotHTML(status)} <span>${escapeHtml(formatted)}</span></span>
+    <li class="py-2">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3">
+        <span class="text-xs sm:text-sm text-[var(--muted)]">${escapeHtml(date)}</span>
+        <span class="flex items-center gap-2 text-sm font-medium break-words">
+          ${dotHTML(status)} <span>${escapeHtml(formatted)}</span>
+        </span>
+      </div>
     </li>
   `;
     })
@@ -437,7 +445,7 @@ export async function renderPractice(ctx, root, _opts = {}) {
   selector.onchange = (e) => {
     const value = e.target.value;
     const base = currentHash.split("?")[0];
-    navigate(`${base}?cat=${encodeURIComponent(value)}`);
+    navigate(`${toAppPath(base)}?cat=${encodeURIComponent(value)}`);
   };
   card.querySelector(".js-new").onclick = () => openConsigneForm(ctx, null);
 
@@ -529,7 +537,7 @@ export async function renderDaily(ctx, root, opts = {}) {
   card.querySelectorAll("[data-day]").forEach((btn) => {
     btn.onclick = () => {
       const base = currentHash.split("?")[0];
-      navigate(`${base}?day=${btn.dataset.day}`);
+      navigate(`${toAppPath(base)}?day=${btn.dataset.day}`);
     };
   });
   card.querySelector(".js-new").onclick = () => openConsigneForm(ctx, null);


### PR DESCRIPTION
## Summary
- prevent double prefixing when routing to user-specific pages and hide the Admin tab on shared links
- normalize in-app navigation so day/category changes reuse the current user context without invalid hashes
- make the header tabs scrollable and history entries responsive for small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11abed2388333a3df46e7565cb8b3