### PR TITLE
Add daily grouping and new response types

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,22 @@
     /* utilitaire pour masquer la scrollbar (déjà utilisé ci-dessus) */
     .no-scrollbar::-webkit-scrollbar{ display:none; }
     .no-scrollbar{ -ms-overflow-style:none; scrollbar-width:none; }
+
+    /* Boutons de jours (Journalier) */
+    .day-btn[data-today="1"] {
+      /* léger surlignage si ce n'est pas le jour sélectionné */
+      box-shadow: inset 0 0 0 2px var(--accent-200);
+    }
+
+    /* Pastilles de priorité */
+    .prio-chip {
+      display:inline-flex; align-items:center; gap:.4rem;
+      padding:.15rem .5rem; border-radius:999px;
+      font-size:.75rem; border:1px solid transparent;
+    }
+    .prio-high   { background:#FEE2E2; border-color:#FCA5A5; color:#B91C1C; } /* rouge doux */
+    .prio-medium { background:#FEF3C7; border-color:#FCD34D; color:#92400E; } /* ambre doux */
+    .prio-low    { background:#E0F2FE; border-color:#BAE6FD; color:#075985; } /* bleu doux */
   </style>
 </head>
 <body class="min-h-screen">

--- a/schema.js
+++ b/schema.js
@@ -34,7 +34,7 @@ export const todayKey = (d = new Date()) => d.toISOString().slice(0,10); // YYYY
 
 export const PRIORITIES = ["high","medium","low"];
 export const MODES = ["daily","practice"];
-export const TYPES = ["short","long","likert6","num"];
+export const TYPES = ["short","long","likert6","likert5","yesno","num"];
 
 export const LIKERT = ["no_answer","no","rather_no","medium","rather_yes","yes"];
 export const LIKERT_POINTS = {
@@ -147,7 +147,9 @@ export function nextCooldownAfterAnswer(meta, prevState, value) {
   // meta.mode === "daily" | "practice", meta.type (likert6/num/short/long)
   let inc = 0;
   if (meta.type === "likert6") inc = likertScore(value);
-  else if (meta.type === "num") inc = Number(value) >= 7 ? 1 : (Number(value) >= 5 ? 0.5 : 0); // simple
+  else if (meta.type === "likert5") inc = Number(value) >= 3 ? 1 : (Number(value) === 2 ? 0.5 : 0);
+  else if (meta.type === "yesno")   inc = (value === "yes") ? 1 : 0;
+  else if (meta.type === "num")     inc = Number(value) >= 7 ? 1 : (Number(value) >= 5 ? 0.5 : 0); // simple
   else inc = 1; // texte => on considère “ok”
 
   let streak = (prevState?.streak || 0);
@@ -287,6 +289,8 @@ export async function fetchResponsesForConsigne(db, uid, consigneId, limitCount 
 
 export function valueToNumericPoint(type, value) {
   if (type === "likert6") return LIKERT_POINTS[value] ?? 0;
+  if (type === "likert5") return Number(value) || 0;  // 0..4
+  if (type === "yesno")   return value === "yes" ? 1 : 0;
   if (type === "num") return Number(value) || 0;
   return null; // pour short/long -> pas de graph
 }


### PR DESCRIPTION
## Summary
- highlight the current day button and surface priority chips while grouping daily consignes by category
- add a "Quotidien" toggle plus Likert 0–4 and Yes/No response options in the consigne form and answer collection flows
- extend history charts and schema utilities to score and chart the new response types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d12e0e6db08333b11daad092351ba1