### PR TITLE
Enable push notifications and automate daily reminders

### DIFF
--- a/.github/workflows/daily-reminder.yml
+++ b/.github/workflows/daily-reminder.yml
@@ -1,0 +1,14 @@
+name: Daily Reminder Notifications
+
+on:
+  schedule:
+    - cron: "0 7 * * *"   # 07:00 UTC = 09:00 Paris
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Firebase HTTPS Function
+        run: |
+          curl -sS "https://us-central1-tracking-d-habitudes.cloudfunctions.net/sendDailyReminders"

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,11 @@ service cloud.firestore {
 
     // Tout l'espace d'un utilisateur accessible publiquement via son UID
     // Exemple : /u/abc123/profile, /u/abc123/goals/..., etc.
+    match /u/{uid}/pushTokens/{token} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow write: if request.auth != null && request.auth.uid == uid;
+    }
+
     match /u/{uid}/{document=**} {
       allow read, write: if true;
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,84 @@
+const functions = require("firebase-functions");
+const admin = require("firebase-admin");
+admin.initializeApp();
+
+const DOW = ["DIM","LUN","MAR","MER","JEU","VEN","SAM"]; // 0..6
+const TODAY_LABEL = () => {
+  const i = new Date().getDay(); // 0=dim
+  return DOW[i];
+};
+const ISO_DAY = () => {
+  const d = new Date(); d.setHours(0,0,0,0);
+  return d.toISOString();
+};
+
+exports.sendDailyReminders = functions.https.onRequest(async (req, res) => {
+  const db = admin.firestore();
+  const todayLabel = TODAY_LABEL();
+  const todayIso = ISO_DAY();
+
+  // Récupérer tous les tokens (et le uid parent)
+  const snap = await db.collectionGroup("pushTokens").get();
+  if (snap.empty) return res.status(200).send("Aucun token.");
+
+  // Grouper par uid
+  const uidTokens = {};
+  snap.forEach(doc => {
+    const data = doc.data();
+    if (data.enabled === false || !data.token) return;
+    const [, uid] = doc.ref.path.split("/"); // /u/{uid}/pushTokens/{token}
+    uidTokens[uid] = uidTokens[uid] || [];
+    uidTokens[uid].push(data.token);
+  });
+
+  // Pour chaque uid: compter consignes visibles aujourd'hui (daily) + pratique si tu veux
+  const messages = [];
+  for (const [uid, tokens] of Object.entries(uidTokens)) {
+    // Consignes daily actives
+    const dailyQs = await db.collection("u").doc(uid).collection("consignes")
+      .where("mode","==","daily").where("active","==",true).get();
+
+    let dailyCount = 0;
+    for (const d of dailyQs.docs) {
+      const c = d.data();
+      const days = Array.isArray(c.days) ? c.days : [];
+      const everyday = days.length === 0;
+      const scheduledToday = everyday || days.includes(todayLabel);
+
+      if (!scheduledToday) continue;
+
+      // SR : lire l'état
+      let visible = true;
+      if (c.srEnabled !== false) {
+        const srDoc = await db.collection("u").doc(uid).collection("sr")
+          .doc(`consigne:${d.id}`).get();
+        const st = srDoc.exists ? srDoc.data() : null;
+        if (st?.nextVisibleOn) {
+          // visible si nextVisibleOn <= aujourd'hui (à minuit)
+          visible = (new Date(st.nextVisibleOn).getTime() <= new Date(todayIso).getTime());
+        }
+      }
+      if (visible) dailyCount++;
+    }
+
+    // Ne rien envoyer si rien à remplir aujourd’hui
+    if (dailyCount <= 0) continue;
+
+    const body = `Tu as ${dailyCount} consigne${dailyCount>1?"s":""} à remplir aujourd’hui.`;
+    messages.push({
+      tokens,
+      notification: { title: "Rappel du jour 👋", body },
+      webpush: { fcmOptions: { link: "https://tracking-d-habitudes.firebaseapp.com/#/daily" } }
+    });
+  }
+
+  if (!messages.length) return res.status(200).send("Aucune notif à envoyer.");
+
+  // Envoi par batches
+  let sent = 0;
+  for (const m of messages) {
+    const resp = await admin.messaging().sendMulticast(m);
+    sent += resp.successCount || 0;
+  }
+  return res.status(200).send(`Notifications envoyées: ${sent}`);
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tracking-d-habitudes-functions",
+  "description": "Firebase Cloud Functions for daily reminders",
+  "version": "1.0.0",
+  "engines": {
+    "node": "20"
+  },
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^4.7.0"
+  }
+}

--- a/schema.js
+++ b/schema.js
@@ -158,6 +158,26 @@ export async function upsertSRState(db, uid, itemId, key, state) {
   await setDoc(docIn(db, uid, "sr", `${key}:${itemId}`), state, { merge: true });
 }
 
+// --- Push tokens (stockés sous /u/{uid}/pushTokens/{token}) ---
+export async function savePushToken(db, uid, token, extra = {}) {
+  await setDoc(docIn(db, uid, "pushTokens", token), {
+    token,
+    ua: navigator.userAgent || "",
+    platform: navigator.platform || "",
+    enabled: true,
+    ...extra,
+    updatedAt: serverTimestamp(),
+    createdAt: serverTimestamp(),
+  }, { merge: true });
+}
+
+export async function disablePushToken(db, uid, token) {
+  await setDoc(docIn(db, uid, "pushTokens", token), {
+    enabled: false,
+    updatedAt: serverTimestamp(),
+  }, { merge: true });
+}
+
 // score pour likert -> 0 / 0.5 / 1
 export function likertScore(v) {
   return ({ yes: 1, rather_yes: 0.5, medium: 0, rather_no: 0, no: 0, no_answer: 0 })[v] ?? 0;

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,29 @@
+// sw.js — Service Worker FCM (web push)
+importScripts("https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js");
+importScripts("https://www.gstatic.com/firebasejs/9.6.10/firebase-messaging-compat.js");
+
+firebase.initializeApp({
+  apiKey: "AIzaSyAQcvZ9a2j4MHF04RjMHIey0R_iwnjZf4o",
+  authDomain: "tracking-d-habitudes.firebaseapp.com",
+  projectId: "tracking-d-habitudes",
+  storageBucket: "tracking-d-habitudes.firebasestorage.app",
+  messagingSenderId: "739389871966",
+  appId: "1:739389871966:web:684e26dbdfb0c0a69221cf"
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(({ notification = {}, data = {} }) => {
+  self.registration.showNotification(notification.title || "Rappel", {
+    body: notification.body || "Tu as des consignes à remplir aujourd’hui.",
+    icon: "/icon.png",
+    badge: "/badge.png",
+    data: { link: data.link || "/" }
+  });
+});
+
+self.addEventListener("notificationclick", (e) => {
+  e.notification.close();
+  const url = e.notification?.data?.link || "/";
+  e.waitUntil(clients.openWindow(url));
+});


### PR DESCRIPTION
## Summary
- add a Firebase Cloud Messaging service worker and client helper to register push tokens
- persist push tokens in Firestore with new schema utilities and security rules
- add a Cloud Function plus a scheduled GitHub Action to send daily reminder notifications

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1541c1d1c8333a131f8f319c50f57