### PR TITLE
Add Firebase push subscription and daily reminder trigger

### DIFF
--- a/.github/workflows/daily-reminder.yml
+++ b/.github/workflows/daily-reminder.yml
@@ -2,7 +2,7 @@ name: Daily Reminder Notifications
 
 on:
   schedule:
-    - cron: "0 7 * * *"   # 07:00 UTC = 09:00 Paris
+    - cron: "0 7 * * *"  # 07:00 UTC = 09:00 Europe/Paris
   workflow_dispatch:
 
 jobs:
@@ -11,4 +11,4 @@ jobs:
     steps:
       - name: Call Firebase HTTPS Function
         run: |
-          curl -sS "https://us-central1-tracking-d-habitudes.cloudfunctions.net/sendDailyReminders"
+          curl -sS "https://europe-west1-tracking-d-habitudes.cloudfunctions.net/sendDailyReminders"

--- a/app.js
+++ b/app.js
@@ -247,8 +247,8 @@ async function ensurePushSubscription(ctx) {
   // 5) Réception en foreground
   onMessage(messaging, (payload) => {
     try {
-      new Notification(payload.notification?.title || "Rappel", {
-        body: payload.notification?.body || "Tu as des consignes à remplir aujourd’hui.",
+      new Notification(payload?.notification?.title || "Rappel", {
+        body: payload?.notification?.body || "Tu as des consignes à remplir aujourd’hui.",
         icon: "/icon.png"
       });
     } catch {}
@@ -290,7 +290,7 @@ export async function initApp({ app, db, user }) {
     log("app:init:hashchange", { route: ctx.route });
     render();
   });
-  render();
+  await render();
   // 👉 Inscription (silencieuse si refus/unsupported)
   ensurePushSubscription(ctx).catch(console.error);
   log("app:init:rendered");

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,7 +2,92 @@ const functions = require("firebase-functions");
 const admin = require("firebase-admin");
 admin.initializeApp();
 
-// Exemple basique pour tester le déploiement
-exports.sendDailyReminders = functions.https.onRequest(async (req, res) => {
-  res.send("Hello depuis Firebase Functions ! 🚀");
+const DOW = ["DIM", "LUN", "MAR", "MER", "JEU", "VEN", "SAM"];
+
+function todayLabel() {
+  return DOW[new Date().getDay()];
+}
+
+function startOfTodayISO() {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+exports.sendDailyReminders = functions.region("europe-west1").https.onRequest(async (req, res) => {
+  const db = admin.firestore();
+  const label = todayLabel();
+  const todayISO = startOfTodayISO();
+  const todayTime = new Date(todayISO).getTime();
+
+  const snap = await db.collectionGroup("pushTokens").get();
+  const uidTokens = {};
+  snap.forEach((doc) => {
+    const data = doc.data();
+    if (data.enabled === false || !data.token) return;
+    const [, uid] = doc.ref.path.split("/");
+    (uidTokens[uid] ||= []).push(data.token);
+  });
+
+  const messages = [];
+  for (const [uid, tokens] of Object.entries(uidTokens)) {
+    const consSnap = await db
+      .collection("u")
+      .doc(uid)
+      .collection("consignes")
+      .where("mode", "==", "daily")
+      .where("active", "==", true)
+      .get();
+
+    let count = 0;
+    for (const d of consSnap.docs) {
+      const c = d.data();
+      const days = Array.isArray(c.days) ? c.days : [];
+      const everyDay = days.length === 0;
+      const scheduledToday = everyDay || days.includes(label);
+      if (!scheduledToday) continue;
+
+      let visible = true;
+      if (c.srEnabled !== false) {
+        const srDoc = await db
+          .collection("u")
+          .doc(uid)
+          .collection("sr")
+          .doc(`consigne:${d.id}`)
+          .get();
+        const st = srDoc.exists ? srDoc.data() : null;
+        const nextISO = st?.nextVisibleOn || st?.hideUntil;
+        if (nextISO && new Date(nextISO).getTime() > todayTime) {
+          visible = false;
+        }
+      }
+
+      if (visible) count++;
+    }
+
+    if (count > 0) {
+      messages.push({
+        tokens,
+        notification: {
+          title: "Rappel du jour 👋",
+          body: `Tu as ${count} consigne${count > 1 ? "s" : ""} à remplir aujourd’hui.`,
+        },
+        webpush: {
+          fcmOptions: { link: "https://vincladef.github.io/code-tracking-prod/#/daily" },
+        },
+      });
+    }
+  }
+
+  if (!messages.length) {
+    return res.status(200).send("Aucune notif à envoyer.");
+  }
+
+  let sent = 0;
+  for (const m of messages) {
+    const r = await admin.messaging().sendMulticast(m);
+    sent += r.successCount || 0;
+  }
+
+  return res.status(200).send(`Notifications envoyées: ${sent}`);
 });

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^12.0.0",
-    "firebase-functions": "^4.7.0"
+    "firebase-admin": "^12.5.0",
+    "firebase-functions": "^5.0.0"
   }
 }

--- a/schema.js
+++ b/schema.js
@@ -162,12 +162,12 @@ export async function upsertSRState(db, uid, itemId, key, state) {
 export async function savePushToken(db, uid, token, extra = {}) {
   await setDoc(docIn(db, uid, "pushTokens", token), {
     token,
+    enabled: true,
     ua: navigator.userAgent || "",
     platform: navigator.platform || "",
-    enabled: true,
-    ...extra,
     updatedAt: serverTimestamp(),
     createdAt: serverTimestamp(),
+    ...extra
   }, { merge: true });
 }
 


### PR DESCRIPTION
## Summary
- subscribe clients to Firebase Cloud Messaging and store push tokens in Firestore
- implement daily reminder Cloud Function and adjust GitHub workflow trigger
- bump functions dependencies to Node 20 compatible Firebase versions

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d1604ea2d48333b26da782acc1a58e