### PR TITLE
Implement objective management and linking

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,15 +3,30 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Tout l'espace d'un utilisateur accessible publiquement via son UID
-    // Exemple : /u/abc123/profile, /u/abc123/goals/..., etc.
-    match /u/{uid}/pushTokens/{token} {
-      allow read: if request.auth != null && request.auth.uid == uid;
-      allow write: if request.auth != null && request.auth.uid == uid;
-    }
+    match /u/{uid} {
+      // Accès au document profil de l'utilisateur
+      allow read, write: if request.auth != null && request.auth.uid == uid;
 
-    match /u/{uid}/{document=**} {
-      allow read, write: if true;
+      match /pushTokens/{token} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow write: if request.auth != null && request.auth.uid == uid;
+      }
+
+      match /objectifs/{objectifId} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow write: if request.auth != null && request.auth.uid == uid;
+      }
+
+      match /consignes/{cid} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow write: if request.auth != null && request.auth.uid == uid;
+        // (pas de restriction spécifique : le champ objectiveId est librement éditable par l’owner)
+      }
+
+      // Autres sous-collections de l'utilisateur (categories, responses, etc.)
+      match /{document=**} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
     }
 
     // Bloquer tout le reste

--- a/goals.js
+++ b/goals.js
@@ -1,7 +1,11 @@
 // goals.js — Objectifs
-import { collection, addDoc, updateDoc, doc, query, orderBy, getDocs, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+import { collection, getDocs } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+import * as Schema from "./schema.js";
 
 const $ = (sel, root = document) => root.querySelector(sel);
+const L = Schema.D;
+
+let lastMount = null;
 
 function escapeHtml(str) {
   return String(str ?? "")
@@ -12,117 +16,318 @@ function escapeHtml(str) {
     .replace(/'/g, "&#39;");
 }
 
-function modal(html) {
-  const wrap = document.createElement("div");
-  wrap.className = "fixed inset-0 z-50 grid place-items-center bg-black/40 p-4";
-  wrap.innerHTML = `
-    <div class="w-[min(640px,92vw)] rounded-2xl bg-white border border-gray-200 p-6 shadow-2xl">
-      ${html}
-    </div>`;
-  wrap.addEventListener("click", (e) => {
-    if (e.target === wrap) wrap.remove();
-  });
-  document.body.appendChild(wrap);
-  return wrap;
+function formatDateInput(dateValue) {
+  if (!dateValue) return "";
+  const d = dateValue instanceof Date ? dateValue : new Date(dateValue);
+  if (Number.isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
-function periodLabel(value) {
-  return (
-    {
-      weekly: "Hebdomadaire",
-      monthly: "Mensuel",
-      yearly: "Annuel"
-    }[value] || value || "—"
-  );
+function formatDateDisplay(value) {
+  const iso = formatDateInput(value);
+  if (iso) return iso;
+  return value ? String(value) : "";
+}
+
+function getCurrentMonthFromHash() {
+  const hash = window.location.hash || "";
+  const match = hash.match(/#\/(?:u\/[^/]+\/)?goals\/(\d{4}-\d{2})/);
+  if (match) return match[1];
+  return Schema.monthKeyFromDate(new Date());
+}
+
+function routeToMonth(monthKey) {
+  if (typeof window.routeTo === "function") {
+    window.routeTo(`#/goals/${monthKey}`);
+  } else {
+    window.location.hash = `#/goals/${monthKey}`;
+  }
+}
+
+function prevMonth(monthKey) {
+  const [y, m] = monthKey.split("-").map(Number);
+  const d = new Date(y, (m || 1) - 2, 1);
+  return Schema.monthKeyFromDate(d);
+}
+
+function nextMonth(monthKey) {
+  const [y, m] = monthKey.split("-").map(Number);
+  const d = new Date(y, (m || 1), 1);
+  return Schema.monthKeyFromDate(d);
+}
+
+function cardOfGoal(o) {
+  const badge = o.type === "hebdo" ? `S${o.weekOfMonth || "?"}` : (o.type === "mensuel" ? "Mois" : "Annuel");
+  const status = o.status === "termine" ? "Terminé" : "En cours";
+  const month = o.monthKey || "";
+  const start = formatDateDisplay(o.startDate);
+  const end = formatDateDisplay(o.endDate);
+  const subtitle = o.type === "hebdo" ? month : (o.type === "annuel" ? `${start} → ${end}` : month);
+  return `
+    <div class="goal-card card" data-goal="${escapeHtml(o.id)}">
+      <div class="goal-card-title">${escapeHtml(o.titre || "Objectif")}</div>
+      <div class="goal-card-sub">${escapeHtml(badge)} ${subtitle ? `— ${escapeHtml(subtitle)}` : ""}</div>
+      <div class="goal-card-status">${escapeHtml(status)}</div>
+    </div>
+  `;
+}
+
+async function openGoalDetail(ctx, objectifId) {
+  try {
+    const goal = await Schema.getObjective(ctx.db, ctx.user.uid, objectifId);
+    if (!goal) return;
+
+    const consSnap = await getDocs(collection(ctx.db, "u", ctx.user.uid, "consignes"));
+    const linked = consSnap.docs
+      .map((d) => ({ id: d.id, ...d.data() }))
+      .filter((c) => c.objectiveId === objectifId);
+
+    const listHtml = linked.length
+      ? `<ul class="goal-list">${linked
+          .map((c) => `<li>${escapeHtml(c.text || c.titre || c.name || c.id)}</li>`)
+          .join("")}</ul>`
+      : '<div class="muted">Aucune consigne liée.</div>';
+
+    const html = `
+      <div class="goal-modal-card">
+        <div class="goal-modal-header">
+          <div>
+            <div class="goal-modal-title">${escapeHtml(goal.titre || "Objectif")}</div>
+            <div class="goal-card-sub">${goal.type === "hebdo" ? `Semaine ${escapeHtml(goal.weekOfMonth || "?")}` : "Période"} — ${escapeHtml(formatDateDisplay(goal.startDate))} → ${escapeHtml(formatDateDisplay(goal.endDate))}</div>
+          </div>
+          <button class="btn-ghost" data-close aria-label="Fermer">✖</button>
+        </div>
+        <p class="mt">${escapeHtml(goal.description || "")}</p>
+        <div class="goal-section mt">
+          <div class="goal-section-title">Consignes liées</div>
+          ${listHtml}
+        </div>
+      </div>
+    `;
+
+    const wrap = document.createElement("div");
+    wrap.className = "goal-modal";
+    wrap.innerHTML = html;
+    wrap.addEventListener("click", (e) => {
+      if (e.target === wrap) wrap.remove();
+    });
+    wrap.querySelector('[data-close]')?.addEventListener('click', () => wrap.remove());
+    document.body.appendChild(wrap);
+  } catch (err) {
+    L.error("goals.detail.error", err);
+  }
 }
 
 export async function renderGoals(ctx, root) {
-  root.innerHTML = `<section class="card p-4 space-y-4">
-    <div class="flex items-center justify-between gap-3">
-      <h2 class="text-xl font-semibold">Objectifs</h2>
-      <button class="btn btn-primary" id="new-goal">+ Nouvel objectif</button>
-    </div>
-    <div class="grid gap-3" id="goals-list"></div>
-  </section>`;
-
-  $("#new-goal", root).onclick = () => openGoalForm(ctx);
-
-  const qy = query(collection(ctx.db, `u/${ctx.user.uid}/goals`), orderBy("createdAt", "desc"));
-  const ss = await getDocs(qy);
-  const list = $("#goals-list", root);
-
-  if (ss.empty) {
-    list.innerHTML = `<div class="rounded-xl border border-dashed border-gray-200 bg-white p-3 text-sm text-[var(--muted)]">Aucun objectif pour le moment.</div>`;
-    return;
+  lastMount = root;
+  const monthKey = getCurrentMonthFromHash();
+  let items = [];
+  try {
+    items = await Schema.listObjectivesByMonth(ctx.db, ctx.user.uid, monthKey);
+  } catch (err) {
+    L.error("goals.list.error", err);
   }
 
-  list.innerHTML = "";
-  ss.forEach((docSnap) => {
-    const goal = { id: docSnap.id, ...docSnap.data() };
-    const card = document.createElement("div");
-    card.className = "card p-3 flex flex-col gap-3";
-    card.innerHTML = `
-      <div class="flex items-start justify-between gap-3">
-        <div>
-          <div class="font-semibold">${escapeHtml(goal.title)}</div>
-          <div class="text-sm text-[var(--muted)]">${periodLabel(goal.period)}</div>
+  const weekly = new Map();
+  const monthly = [];
+  const yearly = [];
+
+  for (const o of items) {
+    if (o.type === "hebdo") {
+      const w = o.weekOfMonth || 1;
+      if (!weekly.has(w)) weekly.set(w, []);
+      weekly.get(w).push(o);
+    } else if (o.type === "annuel") {
+      yearly.push(o);
+    } else {
+      monthly.push(o);
+    }
+  }
+
+  const sortByTitle = (a, b) => (a.titre || "").localeCompare(b.titre || "");
+  weekly.forEach((list) => list.sort(sortByTitle));
+  monthly.sort(sortByTitle);
+  yearly.sort(sortByTitle);
+
+  const weeksHtml = Array.from(weekly.keys())
+    .sort((a, b) => a - b)
+    .map((week) => {
+      const list = weekly.get(week) || [];
+      return `
+        <div class="goal-section">
+          <div class="goal-section-title">Semaine ${week}</div>
+          <div class="goal-grid">${list.map(cardOfGoal).join("")}</div>
         </div>
-        <button class="btn btn-ghost text-sm" data-action="edit">Modifier</button>
+      `;
+    })
+    .join("");
+
+  const monthlyHtml = monthly.length
+    ? `
+      <div class="goal-section">
+        <div class="goal-section-title">Objectifs mensuels</div>
+        <div class="goal-grid">${monthly.map(cardOfGoal).join("")}</div>
       </div>
-    `;
-    card.querySelector('[data-action="edit"]').onclick = () => openGoalForm(ctx, goal);
-    list.appendChild(card);
+    `
+    : "";
+
+  const yearlyHtml = yearly.length
+    ? `
+      <div class="goal-section">
+        <div class="goal-section-title">Objectifs annuels</div>
+        <div class="goal-grid">${yearly.map(cardOfGoal).join("")}</div>
+      </div>
+    `
+    : "";
+
+  const emptyHtml = !items.length
+    ? '<div class="goal-empty muted">Aucun objectif enregistré pour ce mois.</div>'
+    : "";
+
+  root.innerHTML = `
+    <section class="card goal-shell">
+      <div class="goal-top">
+        <div class="goal-nav">
+          <button class="btn-ghost" id="go-prev" aria-label="Mois précédent">⬅️</button>
+          <div class="goal-month">${escapeHtml(monthKey)}</div>
+          <button class="btn-ghost" id="go-next" aria-label="Mois suivant">➡️</button>
+        </div>
+        <button class="btn btn-primary" id="goal-create" aria-label="Nouvel objectif">＋</button>
+      </div>
+      ${weeksHtml}
+      ${monthlyHtml}
+      ${yearlyHtml}
+      ${emptyHtml}
+    </section>
+  `;
+
+  $("#go-prev", root).onclick = () => routeToMonth(prevMonth(monthKey));
+  $("#go-next", root).onclick = () => routeToMonth(nextMonth(monthKey));
+  $("#goal-create", root).onclick = () => openGoalForm(ctx);
+
+  root.querySelectorAll("[data-goal]").forEach((el) => {
+    el.addEventListener("click", () => openGoalDetail(ctx, el.getAttribute("data-goal")));
   });
 }
 
-export async function openGoalForm(ctx, goal = null) {
+export function openGoalForm(ctx, goal = null) {
+  const monthKey = goal?.monthKey || getCurrentMonthFromHash();
+  const defaultStart = goal?.startDate || `${monthKey}-01`;
+  const defaultEnd = goal?.endDate || `${monthKey}-28`;
+  const defaultWeek = goal?.weekOfMonth || Schema.weekOfMonthFromDate(defaultStart);
   const html = `
-    <h3 class="text-lg font-semibold mb-2">${goal ? "Modifier" : "Nouvel"} objectif</h3>
-    <form class="grid gap-4" id="goal-form">
-      <label class="grid gap-1">
-        <span class="text-sm text-[var(--muted)]">Titre</span>
-        <input name="title" required class="w-full" value="${escapeHtml(goal?.title || "")}">
-      </label>
-      <label class="grid gap-1">
-        <span class="text-sm text-[var(--muted)]">Périodicité</span>
-        <select name="period" class="w-full">
-          <option value="weekly" ${goal?.period === "weekly" ? "selected" : ""}>Hebdomadaire</option>
-          <option value="monthly" ${goal?.period === "monthly" ? "selected" : ""}>Mensuel</option>
-          <option value="yearly" ${goal?.period === "yearly" ? "selected" : ""}>Annuel</option>
-        </select>
-      </label>
-      <div class="flex justify-end gap-2 pt-2">
-        <button type="button" class="btn btn-ghost" id="cancel">Annuler</button>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
+    <div class="goal-modal-card">
+      <div class="goal-modal-header">
+        <div class="goal-modal-title">${goal ? "Modifier" : "Nouvel"} objectif</div>
+        <button class="btn-ghost" data-close aria-label="Fermer">✖</button>
       </div>
-    </form>`;
-  const m = modal(html);
-  $("#cancel", m).onclick = () => m.remove();
-  $("#goal-form", m).onsubmit = async (e) => {
+      <form class="goal-form" id="goal-form">
+        <label class="goal-field">
+          <span class="goal-label">Titre</span>
+          <input name="titre" required class="goal-input" value="${escapeHtml(goal?.titre || "")}">
+        </label>
+        <label class="goal-field">
+          <span class="goal-label">Type</span>
+          <select name="type" id="goal-type" class="goal-input">
+            <option value="hebdo" ${goal?.type === "hebdo" ? "selected" : ""}>Hebdomadaire</option>
+            <option value="mensuel" ${!goal || goal?.type === "mensuel" ? "selected" : ""}>Mensuel</option>
+            <option value="annuel" ${goal?.type === "annuel" ? "selected" : ""}>Annuel</option>
+          </select>
+        </label>
+        <div class="goal-field" data-week-row>
+          <span class="goal-label">Semaine du mois</span>
+          <select name="weekOfMonth" class="goal-input">
+            ${[1, 2, 3, 4, 5, 6]
+              .map((w) => `<option value="${w}" ${Number(defaultWeek) === w ? "selected" : ""}>Semaine ${w}</option>`)
+              .join("")}
+          </select>
+        </div>
+        <label class="goal-field">
+          <span class="goal-label">Date de début</span>
+          <input type="date" name="startDate" class="goal-input" value="${escapeHtml(formatDateInput(defaultStart))}">
+        </label>
+        <label class="goal-field">
+          <span class="goal-label">Date de fin</span>
+          <input type="date" name="endDate" class="goal-input" value="${escapeHtml(formatDateInput(defaultEnd))}">
+        </label>
+        <label class="goal-field">
+          <span class="goal-label">Description</span>
+          <textarea name="description" rows="3" class="goal-input">${escapeHtml(goal?.description || "")}</textarea>
+        </label>
+        <label class="goal-field">
+          <span class="goal-label">Statut</span>
+          <select name="status" class="goal-input">
+            <option value="en_cours" ${goal?.status !== "termine" ? "selected" : ""}>En cours</option>
+            <option value="termine" ${goal?.status === "termine" ? "selected" : ""}>Terminé</option>
+          </select>
+        </label>
+        <div class="goal-actions">
+          <button type="button" class="btn btn-ghost" data-close>Annuler</button>
+          <button type="submit" class="btn btn-primary">Enregistrer</button>
+        </div>
+      </form>
+    </div>
+  `;
+
+  const wrap = document.createElement("div");
+  wrap.className = "goal-modal";
+  wrap.innerHTML = html;
+  document.body.appendChild(wrap);
+
+  const close = () => wrap.remove();
+  wrap.addEventListener("click", (e) => {
+    if (e.target === wrap) close();
+  });
+  wrap.querySelectorAll('[data-close]').forEach((btn) => btn.addEventListener('click', close));
+
+  const typeSelect = wrap.querySelector("#goal-type");
+  const weekRow = wrap.querySelector('[data-week-row]');
+  const syncWeekRow = () => {
+    if (!weekRow) return;
+    weekRow.style.display = typeSelect.value === "hebdo" ? "" : "none";
+  };
+  syncWeekRow();
+  typeSelect.addEventListener("change", syncWeekRow);
+
+  wrap.querySelector("#goal-form").addEventListener("submit", async (e) => {
     e.preventDefault();
     const fd = new FormData(e.currentTarget);
-    const payload = {
-      title: fd.get("title").trim(),
-      period: fd.get("period"),
-      active: true,
-      createdAt: serverTimestamp()
-    };
-    if (!payload.title) {
-      alert("Titre obligatoire");
+    const titre = (fd.get("titre") || "").toString().trim();
+    if (!titre) {
+      alert("Le titre est obligatoire.");
       return;
     }
-    if (goal) {
-      await updateDoc(doc(ctx.db, `u/${ctx.user.uid}/goals/${goal.id}`), {
-        ...payload,
-        updatedAt: serverTimestamp()
-      });
-    } else {
-      await addDoc(collection(ctx.db, `u/${ctx.user.uid}/goals`), {
-        ownerUid: ctx.user.uid,
-        ...payload
-      });
+
+    const data = {
+      titre,
+      type: fd.get("type") || "mensuel",
+      description: (fd.get("description") || "").toString().trim(),
+      startDate: fd.get("startDate") || defaultStart,
+      endDate: fd.get("endDate") || defaultEnd,
+      status: fd.get("status") || "en_cours",
+    };
+    if (data.type === "hebdo") {
+      data.weekOfMonth = Number(fd.get("weekOfMonth") || defaultWeek || 1);
     }
-    m.remove();
-    renderGoals(ctx, document.getElementById("view-root"));
-  };
+    data.monthKey = Schema.monthKeyFromDate(data.startDate);
+
+    try {
+      await Schema.upsertObjective(ctx.db, ctx.user.uid, data, goal?.id || null);
+    } catch (err) {
+      L.error("goals.save.error", err);
+      alert("Impossible d'enregistrer l'objectif.");
+      return;
+    }
+
+    close();
+    if (lastMount) {
+      renderGoals(ctx, lastMount);
+    } else {
+      const mount = document.getElementById("view-root");
+      if (mount) renderGoals(ctx, mount);
+    }
+  });
 }

--- a/index.html
+++ b/index.html
@@ -90,6 +90,31 @@
     .prio-low    { background:#E0F2FE; border-color:#BAE6FD; color:#075985; } /* bleu doux */
 
     .btn-saved{ background:#22C55E; } /* vert doux rapide pour le flash */
+
+    /* Objectifs */
+    .goal-shell{ padding:1.25rem 1.5rem; display:flex; flex-direction:column; gap:1rem; }
+    .goal-top{ display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
+    .goal-nav{ display:flex; align-items:center; gap:.75rem; }
+    .goal-month{ font-weight:600; font-size:1.1rem; }
+    .goal-section{ display:flex; flex-direction:column; gap:.5rem; margin-top:.25rem; }
+    .goal-section-title{ font-weight:600; color:var(--muted); }
+    .goal-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(220px,1fr)); gap:.75rem; }
+    .goal-card{ padding:.9rem; transition:transform .15s ease, box-shadow .15s ease; cursor:pointer; }
+    .goal-card:hover{ transform:translateY(-2px); box-shadow:0 12px 24px rgba(148,163,184,.25); }
+    .goal-card-title{ font-weight:600; }
+    .goal-card-sub{ color:var(--muted); font-size:.85rem; margin-top:.15rem; }
+    .goal-card-status{ color:#0f172a; font-size:.85rem; margin-top:.4rem; font-weight:500; }
+    .goal-empty{ padding:1rem; border-radius:.75rem; background:var(--accent-50); }
+    .goal-modal{ position:fixed; inset:0; background:rgba(15,23,42,.18); display:grid; place-items:center; padding:1rem; z-index:50; }
+    .goal-modal-card{ background:#fff; border-radius:1rem; padding:1.25rem 1.5rem; box-shadow:0 24px 48px rgba(15,23,42,.16); width:min(720px,95vw); max-height:90vh; overflow:auto; }
+    .goal-modal-header{ display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; }
+    .goal-modal-title{ font-weight:700; font-size:1.1rem; }
+    .goal-form{ display:grid; gap:1rem; margin-top:1rem; }
+    .goal-field{ display:grid; gap:.4rem; }
+    .goal-label{ font-size:.85rem; color:var(--muted); }
+    .goal-input{ width:100%; }
+    .goal-actions{ display:flex; justify-content:flex-end; gap:.5rem; }
+    .goal-list{ margin-top:.5rem; padding-left:1.25rem; display:grid; gap:.35rem; list-style:disc; }
   </style>
 </head>
 <body class="min-h-screen">


### PR DESCRIPTION
## Summary
- tighten security rules for user objectifs and allow consigne linking fields
- add shared schema helpers to list, fetch and persist objectifs plus link consignes
- extend consigne editor with optional objective picker saved alongside the consigne
- rebuild the goals tab with month navigation, grouped cards, detail modal and inline creation form
- style the new goal sections and modals to match the existing UI

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d17ecb32ac833395af07b1bed56071