### PR TITLE
Adjust admin visibility and guidance

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,16 @@ export const ctx = {
 async function refreshUserBadge(uid) {
   const el = document.querySelector("[data-username]");
   if (!el) return;
+  const currentHash = ctx.route || location.hash || "#/admin";
+  const { segments } = parseHash(currentHash);
+  const routeKey = segments[0] || "admin";
+  const isAdminRoute = routeKey === "admin";
+
+  if (isAdminRoute) {
+    el.textContent = "Admin";
+    return;
+  }
+
   if (!uid) {
     el.textContent = "Utilisateur";
     return;
@@ -515,8 +525,13 @@ async function loadUsers(db) {
       list.dataset.bound = "1";
     }
   } catch (error) {
-    console.error("admin:users:load:error", error);
-    list.innerHTML = "<div class='text-sm text-red-600'>Accès refusé ou indisponible.</div>";
+    console.warn("admin:users:load:error", error);
+    list.innerHTML = [
+      "<div class='space-y-2 text-sm text-red-600'>",
+      "  <div>Accès refusé. Ajoute ton UID dans <code>/admins/{uid}</code> depuis la console Firebase.</div>",
+      "  <div class='text-xs text-[var(--muted)]'>Authentication → Users pour récupérer l’UID actuel.</div>",
+      "</div>"
+    ].join("");
   }
 }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,11 +11,13 @@ service cloud.firestore {
 
     match /u/{uid} {
       match /{document=**} {
+        // l’owner OU un admin
         allow read, write: if isOwner(uid) || isAdmin();
       }
     }
 
     match /admins/{adminUid} {
+      // petite collection d'admins
       allow read: if isAdmin();
       allow write: if false;
     }

--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
     .tab{ border:1px solid #E5E7EB; background:#fff; border-radius:999px; padding:.5rem .875rem; font-size:.9rem; display:inline-flex; gap:.5rem; align-items:center; white-space:nowrap; flex:0 0 auto; }
     .tab[aria-current="page"]{ background:var(--accent-50); border-color:var(--accent-400); color:#0B4B66; }
 
+    /* cache le bouton Admin partout */
+    [data-nav="admin"] { display: none !important; }
+
     /* Boutons */
     .btn{ border-radius:.75rem; padding:.625rem 1rem; font-weight:600; }
     .btn-primary{ background:var(--accent-600); color:#fff; }
@@ -130,7 +133,7 @@
           </span>
         </h1>
         <nav class="tabs w-full sm:w-auto overflow-x-auto no-scrollbar">
-          <button class="tab" data-route="#/admin"><span>🛠️</span><span>Admin</span></button>
+          <button class="tab" data-route="#/admin" data-nav="admin"><span>🛠️</span><span>Admin</span></button>
           <button class="tab" data-route="#/daily"><span>📅</span><span>Journalier</span></button>
           <button class="tab" data-route="#/practice"><span>⚡</span><span>Pratique</span></button>
           <button class="tab" data-route="#/goals"><span>🎯</span><span>Objectifs</span></button>


### PR DESCRIPTION
## Summary
- hide the admin navigation pill with a data attribute while keeping the route functional
- show an "Admin" badge in the header and improve the Firestore access error copy for the admin view
- document the Firestore rule intent so admin ownership requirements are explicit

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d19d9e733c8333b880332f3d8be7a2