### PR TITLE
Allow anonymous admin access

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,8 +34,7 @@ export const ctx = {
 async function refreshUserBadge(uid) {
   const el = document.querySelector("[data-username]");
   if (!el) return;
-  const currentHash = ctx.route || location.hash || "#/admin";
-  const { segments } = parseHash(currentHash);
+  const { segments } = parseHash(ctx.route || location.hash || "#/admin");
   const routeKey = segments[0] || "admin";
   const isAdminRoute = routeKey === "admin";
 
@@ -474,7 +473,7 @@ export function renderAdmin(db) {
         loadUsers(db);
       } catch (error) {
         console.error("admin:newUser:error", error);
-        alert("Création impossible (accès refusé ?)");
+        alert("Création impossible. Réessaie plus tard.");
       }
     });
   }
@@ -526,12 +525,7 @@ async function loadUsers(db) {
     }
   } catch (error) {
     console.warn("admin:users:load:error", error);
-    list.innerHTML = [
-      "<div class='space-y-2 text-sm text-red-600'>",
-      "  <div>Accès refusé. Ajoute ton UID dans <code>/admins/{uid}</code> depuis la console Firebase.</div>",
-      "  <div class='text-xs text-[var(--muted)]'>Authentication → Users pour récupérer l’UID actuel.</div>",
-      "</div>"
-    ].join("");
+    list.innerHTML = "<div class='text-sm text-red-600'>Impossible de charger les utilisateurs.</div>";
   }
 }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,24 +1,19 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    function isAdmin() {
-      return request.auth != null
-        && exists(/databases/$(database)/documents/admins/$(request.auth.uid));
-    }
-    function isOwner(uid) {
-      return request.auth != null && request.auth.uid == uid;
-    }
 
+    // TOUT utilisateur connecté (anonyme inclus) peut lire/écrire n'importe quel user
     match /u/{uid} {
+      // le doc racine et TOUT ce qu'il contient
+      allow read, write: if request.auth != null;
       match /{document=**} {
-        // l’owner OU un admin
-        allow read, write: if isOwner(uid) || isAdmin();
+        allow read, write: if request.auth != null;
       }
     }
 
+    // On verrouille la collection admins (inutile désormais)
     match /admins/{adminUid} {
-      // petite collection d'admins
-      allow read: if isAdmin();
+      allow read: if false;
       allow write: if false;
     }
   }


### PR DESCRIPTION
## Summary
- relax Firestore rules so any authenticated (including anonymous) user can manage user documents while locking down the admins collection
- simplify admin UI messaging now that special admin access is no longer required

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1a180900883339c2cb5d1eb182790