### PR TITLE
Restore global script usage without ES modules

### DIFF
--- a/goals.js
+++ b/goals.js
@@ -1,7 +1,7 @@
 // goals.js — Objectifs timeline
-import * as Schema from "./schema.js";
-
-const L = Schema.D;
+const Schema = window.Schema || {};
+const Goals = window.Goals = window.Goals || {};
+const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
 let lastMount = null;
 
@@ -30,7 +30,7 @@ function typeLabel(goal) {
   return goal.type || "Objectif";
 }
 
-export async function renderGoals(ctx, root) {
+async function renderGoals(ctx, root) {
   lastMount = root;
   root.innerHTML = "";
 
@@ -209,7 +209,7 @@ export async function renderGoals(ctx, root) {
   observer.observe(bottomSentinel);
 }
 
-export function openGoalForm(ctx, goal = null) {
+function openGoalForm(ctx, goal = null) {
   const monthKey = goal?.monthKey || Schema.monthKeyFromDate(new Date());
   let weekOfMonth = Number(goal?.weekOfMonth || 1);
   const typeInitial = goal?.type || "hebdo";
@@ -320,3 +320,6 @@ export function openGoalForm(ctx, goal = null) {
     }
   });
 }
+
+Goals.renderGoals = renderGoals;
+Goals.openGoalForm = openGoalForm;

--- a/index.html
+++ b/index.html
@@ -159,23 +159,37 @@
     </footer>
   </div>
 
-  <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getFirestore } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-    import { startRouter } from "./app.js";
-
-    const cfg = {
-      apiKey: "AIzaSyAQcvZ9a2j4MHF04RjMHIey0R_iwnjZf4o",
-      authDomain: "tracking-d-habitudes.firebaseapp.com",
-      projectId: "tracking-d-habitudes",
-      storageBucket: "tracking-d-habitudes.firebasestorage.app",
-      messagingSenderId: "739389871966",
-      appId: "1:739389871966:web:684e26dbdfb0c0a69221cf",
-      measurementId: "G-ZPHWB5DKWF"
-    };
-    const app = initializeApp(cfg);
-    const db = getFirestore(app);
-    startRouter(app, db);
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js"></script>
+  <script src="schema.js"></script>
+  <script src="modes.js"></script>
+  <script src="goals.js"></script>
+  <script src="app.js"></script>
+  <script>
+    (function initApp() {
+      if (!window.firebase) {
+        console.error("Firebase non chargé");
+        return;
+      }
+      const cfg = {
+        apiKey: "AIzaSyAQcvZ9a2j4MHF04RjMHIey0R_iwnjZf4o",
+        authDomain: "tracking-d-habitudes.firebaseapp.com",
+        projectId: "tracking-d-habitudes",
+        storageBucket: "tracking-d-habitudes.firebasestorage.app",
+        messagingSenderId: "739389871966",
+        appId: "1:739389871966:web:684e26dbdfb0c0a69221cf",
+        measurementId: "G-ZPHWB5DKWF"
+      };
+      const app = firebase.initializeApp(cfg);
+      const db = firebase.firestore(app);
+      if (typeof startRouter === "function") {
+        startRouter(app, db);
+      } else {
+        console.error("startRouter indisponible");
+      }
+    })();
   </script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 </body>

--- a/modes.js
+++ b/modes.js
@@ -1,8 +1,10 @@
 // modes.js — Journalier / Pratique / Historique
-import { collection, query, where, orderBy, limit, getDocs } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-import * as Schema from "./schema.js";
+const Schema = window.Schema || {};
+const Modes = window.Modes = window.Modes || {};
+const firestoreAPI = Schema.firestore || {};
+const { collection, query, where, orderBy, limit, getDocs } = firestoreAPI;
 
-const L = Schema.D;
+const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
 const $ = (sel, root = document) => root.querySelector(sel);
 const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
@@ -316,7 +318,7 @@ function collectAnswers(form, consignes) {
   return answers;
 }
 
-export async function openConsigneForm(ctx, consigne = null) {
+async function openConsigneForm(ctx, consigne = null) {
   const mode = consigne?.mode || (ctx.route.includes("/practice") ? "practice" : "daily");
   L.group("ui.consigneForm.open", { mode, consigneId: consigne?.id || null });
   const catUI = await categorySelect(ctx, mode, consigne?.category || null);
@@ -500,7 +502,7 @@ function dotHTML(kind){
   return `<span style="display:inline-block;width:.6rem;height:.6rem;border-radius:999px;${style}"></span>`;
 }
 
-export async function openHistory(ctx, consigne) {
+async function openHistory(ctx, consigne) {
   L.group("ui.history.open", { consigneId: consigne.id, type: consigne.type });
   const qy = query(
     collection(ctx.db, `u/${ctx.user.uid}/responses`),
@@ -644,7 +646,7 @@ export async function openHistory(ctx, consigne) {
   }
 }
 
-export async function renderPractice(ctx, root, _opts = {}) {
+async function renderPractice(ctx, root, _opts = {}) {
   L.group("screen.practice.render", { hash: ctx.route });
   root.innerHTML = "";
   const container = document.createElement("div");
@@ -924,7 +926,7 @@ function daysBetween(a,b){
   return Math.max(0, Math.round(ms/86400000));
 }
 
-export async function renderDaily(ctx, root, opts = {}) {
+async function renderDaily(ctx, root, opts = {}) {
   root.innerHTML = "";
   const container = document.createElement("div");
   container.className = "space-y-4";
@@ -1149,4 +1151,13 @@ export async function renderDaily(ctx, root, opts = {}) {
   L.groupEnd();
 }
 
-export function renderHistory() {}
+function renderHistory() {}
+
+Modes.openCategoryDashboard = openCategoryDashboard;
+Modes.openConsigneForm = openConsigneForm;
+Modes.openHistory = openHistory;
+Modes.renderPractice = renderPractice;
+Modes.renderDaily = renderDaily;
+Modes.renderHistory = renderHistory;
+
+window.openCategoryDashboard = openCategoryDashboard;


### PR DESCRIPTION
## Summary
- replace ES module imports/exports with global namespace assignments in schema, modes, goals, and app
- add Firebase compat helpers and expose module APIs on `window` to match the non-module script loading order
- update `index.html` to load Firebase compat scripts and bootstrap the app via a global initializer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d27b4a55a88333b3f0c156306118c1