### PR TITLE
Fix global namespace usage to prevent redeclaration errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,6 @@
 // app.js — bootstrapping, routing, context, nav
-/* global Schema */
-const Modes = window.Modes || {};
-const Goals = window.Goals || {};
-
-const firestoreAPI = Schema.firestore || {};
-const { collection, query, where, orderBy, limit, getDocs, doc, setDoc, getDoc } = firestoreAPI;
+/* global Schema, Modes, Goals */
+const { collection, query, where, orderBy, limit, getDocs, doc, setDoc, getDoc } = Schema.firestore || window.firestoreAPI || {};
 
 const firebaseCompat = window.firebase || {};
 

--- a/goals.js
+++ b/goals.js
@@ -1,6 +1,6 @@
 // goals.js — Objectifs timeline
-/* global Schema */
-const Goals = window.Goals = window.Goals || {};
+/* global Schema, Goals */
+window.Goals = window.Goals || {};
 const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
 let lastMount = null;

--- a/modes.js
+++ b/modes.js
@@ -1,8 +1,7 @@
 // modes.js — Journalier / Pratique / Historique
-/* global Schema */
-const Modes = window.Modes = window.Modes || {};
-const firestoreAPI = Schema.firestore || {};
-const { collection, query, where, orderBy, limit, getDocs } = firestoreAPI;
+/* global Schema, Modes */
+window.Modes = window.Modes || {};
+const { collection, query, where, orderBy, limit, getDocs } = Schema.firestore || window.firestoreAPI || {};
 
 const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 

--- a/schema.js
+++ b/schema.js
@@ -1,5 +1,5 @@
+/* global Schema */
 window.Schema = window.Schema || {};
-const Schema = window.Schema;
 
 const firebaseCompat = window.firebase || {};
 const firestoreCompat = firebaseCompat.firestore;
@@ -36,7 +36,7 @@ function docFromCompat(base, ...segments) {
   return base.doc(path);
 }
 
-const firestoreAPI = firestoreCompat
+window.firestoreAPI = window.firestoreAPI || (firestoreCompat
   ? {
       getFirestore: (app) => firebaseCompat.firestore(app),
       collection: collectionFromCompat,
@@ -45,7 +45,8 @@ const firestoreAPI = firestoreCompat
       getDoc: (ref) => ref.get(),
       getDocs: (qry) => qry.get(),
       addDoc: (ref, data) => ref.add(data),
-      query: (base, ...constraints) => constraints.reduce((ref, fn) => (typeof fn === "function" ? fn(ref) : ref), base),
+      query: (base, ...constraints) =>
+        constraints.reduce((ref, fn) => (typeof fn === "function" ? fn(ref) : ref), base),
       where: (field, op, value) => (ref) => ref.where(field, op, value),
       orderBy: (field, direction) => (ref) => ref.orderBy(field, direction),
       updateDoc: (ref, data) => ref.update(data),
@@ -66,9 +67,9 @@ const firestoreAPI = firestoreCompat
       updateDoc: () => missingFirestoreWarning(),
       limit: () => missingFirestoreWarning(),
       serverTimestamp: () => missingFirestoreWarning(),
-    };
+    });
 
-Schema.firestore = Schema.firestore || firestoreAPI;
+Schema.firestore = Schema.firestore || window.firestoreAPI;
 
 const {
   collection,


### PR DESCRIPTION
## Summary
- ensure schema.js initialises the Schema namespace and shared firestoreAPI once on window
- update modes.js and goals.js to reuse window-level namespaces without redeclaring globals
- load Firestore helpers in app.js from the shared Schema/window singleton to avoid duplicate consts

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d28b9ddd78833396f3a2b24d3cd8d0