### PR TITLE
Refine Firestore access scoping

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // app.js — bootstrapping, routing, context, nav
 /* global Schema, Modes, Goals */
-const { collection, query, where, orderBy, limit, getDocs, doc, setDoc, getDoc } = Schema.firestore || window.firestoreAPI || {};
+const appFirestore = Schema.firestore || window.firestoreAPI || {};
 
 const firebaseCompat = window.firebase || {};
 
@@ -361,8 +361,8 @@ function startRouter(app, db) {
 // Local ensureProfile function
 async function ensureProfile(db, uid) {
   log("profile:ensure:start", { uid });
-  const ref = doc(db, "u", uid);
-  const snap = await getDoc(ref);
+  const ref = appFirestore.doc(db, "u", uid);
+  const snap = await appFirestore.getDoc(ref);
   if (snap.exists()) {
     const data = snap.data();
     log("profile:ensure:existing", { uid });
@@ -372,7 +372,7 @@ async function ensureProfile(db, uid) {
     displayName: "Nouvel utilisateur",
     createdAt: new Date().toISOString()
   };
-  await setDoc(ref, newProfile);
+  await appFirestore.setDoc(ref, newProfile);
   log("profile:ensure:created", { uid });
   return newProfile;
 }
@@ -506,7 +506,7 @@ function renderAdmin(db) {
       log("admin:newUser:submit", { name });
       const uid = newUid();
       try {
-        await setDoc(doc(db, "u", uid), {
+        await appFirestore.setDoc(appFirestore.doc(db, "u", uid), {
           displayName: name,
           createdAt: new Date().toISOString()
         });
@@ -529,7 +529,7 @@ async function loadUsers(db) {
   list.innerHTML = "<div class='text-sm text-[var(--muted)]'>Chargement…</div>";
   log("admin:users:load:start");
   try {
-    const ss = await getDocs(collection(db, "u"));
+    const ss = await appFirestore.getDocs(appFirestore.collection(db, "u"));
     const items = [];
     ss.forEach(d => {
       const data = d.data();

--- a/modes.js
+++ b/modes.js
@@ -1,7 +1,7 @@
 // modes.js — Journalier / Pratique / Historique
 /* global Schema, Modes */
 window.Modes = window.Modes || {};
-const { collection, query, where, orderBy, limit, getDocs } = Schema.firestore || window.firestoreAPI || {};
+const modesFirestore = Schema.firestore || window.firestoreAPI || {};
 
 const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
@@ -505,13 +505,13 @@ function dotHTML(kind){
 
 async function openHistory(ctx, consigne) {
   L.group("ui.history.open", { consigneId: consigne.id, type: consigne.type });
-  const qy = query(
-    collection(ctx.db, `u/${ctx.user.uid}/responses`),
-    where("consigneId", "==", consigne.id),
-    orderBy("createdAt", "desc"),
-    limit(60)
+  const qy = modesFirestore.query(
+    modesFirestore.collection(ctx.db, `u/${ctx.user.uid}/responses`),
+    modesFirestore.where("consigneId", "==", consigne.id),
+    modesFirestore.orderBy("createdAt", "desc"),
+    modesFirestore.limit(60)
   );
-  const ss = await getDocs(qy);
+  const ss = await modesFirestore.getDocs(qy);
   L.info("ui.history.rows", ss.size);
   const rows = ss.docs.map((d) => ({ id: d.id, ...d.data() }));
 


### PR DESCRIPTION
## Summary
- switch modes.js to use a single local Firestore namespace instead of destructured globals
- update app.js to read Firestore helpers through a local namespace object
- ensure calls throughout both files reference the scoped helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28e6d7870833399aed019225b3a08