### PR TITLE
Fix duplicate global logger declarations

### DIFF
--- a/goals.js
+++ b/goals.js
@@ -1,7 +1,7 @@
 // goals.js — Objectifs timeline
 /* global Schema, Goals */
 window.Goals = window.Goals || {};
-const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+const logger = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
 let lastMount = null;
 
@@ -106,7 +106,7 @@ async function renderGoals(ctx, root) {
         row.style.outline = "2px solid #86efac";
         setTimeout(() => { row.style.outline = "none"; }, 600);
       } catch (err) {
-        L.error("goals.quickEntry.error", err);
+        logger.error("goals.quickEntry.error", err);
         row.style.outline = "2px solid #fca5a5";
         setTimeout(() => { row.style.outline = "none"; }, 800);
       }
@@ -152,7 +152,7 @@ async function renderGoals(ctx, root) {
     try {
       goals = await Schema.listObjectivesByMonth(ctx.db, ctx.user.uid, monthKey);
     } catch (err) {
-      L.error("goals.month.load", err);
+      logger.error("goals.month.load", err);
     }
 
     goals.sort((a, b) => (a.titre || "").localeCompare(b.titre || ""));
@@ -315,7 +315,7 @@ function openGoalForm(ctx, goal = null) {
         renderGoals(ctx, lastMount);
       }
     } catch (err) {
-      L.error("goals.save.error", err);
+      logger.error("goals.save.error", err);
       alert("Impossible d'enregistrer l’objectif.");
     }
   });

--- a/modes.js
+++ b/modes.js
@@ -3,7 +3,7 @@
 window.Modes = window.Modes || {};
 const modesFirestore = Schema.firestore || window.firestoreAPI || {};
 
-const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+const logger = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
 const $ = (sel, root = document) => root.querySelector(sel);
 const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
@@ -321,7 +321,7 @@ function collectAnswers(form, consignes) {
 
 async function openConsigneForm(ctx, consigne = null) {
   const mode = consigne?.mode || (ctx.route.includes("/practice") ? "practice" : "daily");
-  L.group("ui.consigneForm.open", { mode, consigneId: consigne?.id || null });
+  logger.group("ui.consigneForm.open", { mode, consigneId: consigne?.id || null });
   const catUI = await categorySelect(ctx, mode, consigne?.category || null);
   const priority = Number(consigne?.priority ?? 2);
   const monthKey = Schema.monthKeyFromDate(new Date());
@@ -329,7 +329,7 @@ async function openConsigneForm(ctx, consigne = null) {
   try {
     objectifs = await Schema.listObjectivesByMonth(ctx.db, ctx.user.uid, monthKey);
   } catch (err) {
-    L.warn("ui.consigneForm.objectifs.error", err);
+    logger.warn("ui.consigneForm.objectifs.error", err);
   }
   const currentObjId = consigne?.objectiveId || "";
   const objectifsOptions = objectifs
@@ -422,12 +422,12 @@ async function openConsigneForm(ctx, consigne = null) {
     if (dailyAll.checked) setAll(true);
     dailyAll.addEventListener("change", () => setAll(dailyAll.checked));
   }
-  L.groupEnd();
+  logger.groupEnd();
   $("#cancel", m).onclick = () => m.remove();
 
   $("#consigne-form", m).onsubmit = async (e) => {
     e.preventDefault();
-    L.group("ui.consigneForm.submit");
+    logger.group("ui.consigneForm.submit");
     try {
       const fd = new FormData(e.currentTarget);
       const cat = (fd.get("categoryInput") || "").trim();
@@ -452,7 +452,7 @@ async function openConsigneForm(ctx, consigne = null) {
         const isAll = m.querySelector("#daily-all")?.checked;
         payload.days = isAll ? [] : $$("input[name=days]:checked", m).map((input) => input.value);
       }
-      L.info("payload", payload);
+      logger.info("payload", payload);
 
       const selectedObjective = m.querySelector("#objective-select")?.value || "";
       let consigneId = consigne?.id || null;
@@ -471,7 +471,7 @@ async function openConsigneForm(ctx, consigne = null) {
       if (mode === "practice") renderPractice(ctx, root);
       else renderDaily(ctx, root);
     } finally {
-      L.groupEnd();
+      logger.groupEnd();
     }
   };
 }
@@ -504,7 +504,7 @@ function dotHTML(kind){
 }
 
 async function openHistory(ctx, consigne) {
-  L.group("ui.history.open", { consigneId: consigne.id, type: consigne.type });
+  logger.group("ui.history.open", { consigneId: consigne.id, type: consigne.type });
   const qy = modesFirestore.query(
     modesFirestore.collection(ctx.db, `u/${ctx.user.uid}/responses`),
     modesFirestore.where("consigneId", "==", consigne.id),
@@ -512,7 +512,7 @@ async function openHistory(ctx, consigne) {
     modesFirestore.limit(60)
   );
   const ss = await modesFirestore.getDocs(qy);
-  L.info("ui.history.rows", ss.size);
+  logger.info("ui.history.rows", ss.size);
   const rows = ss.docs.map((d) => ({ id: d.id, ...d.data() }));
 
   const list = rows
@@ -550,7 +550,7 @@ async function openHistory(ctx, consigne) {
   panel.querySelector('[data-close]')?.addEventListener('click', () => panel.remove());
 
   if (canGraph && window.Chart) {
-    L.info("ui.history.chart", { points: rows.length });
+    logger.info("ui.history.chart", { points: rows.length });
     const canvas = panel.querySelector('#histoChart');
     if (canvas) {
       const ctx2 = canvas.getContext('2d');
@@ -611,10 +611,10 @@ async function openHistory(ctx, consigne) {
       });
     }
   } else {
-    L.info("ui.history.chart.skip", { canGraph, hasChart: !!window.Chart });
+    logger.info("ui.history.chart.skip", { canGraph, hasChart: !!window.Chart });
   }
 
-  L.groupEnd();
+  logger.groupEnd();
 
   function formatValue(type, v) {
     if (type === 'yesno') return v === 'yes' ? 'Oui' : 'Non';
@@ -648,7 +648,7 @@ async function openHistory(ctx, consigne) {
 }
 
 async function renderPractice(ctx, root, _opts = {}) {
-  L.group("screen.practice.render", { hash: ctx.route });
+  logger.group("screen.practice.render", { hash: ctx.route });
   root.innerHTML = "";
   const container = document.createElement("div");
   container.className = "space-y-4";
@@ -721,7 +721,7 @@ async function renderPractice(ctx, root, _opts = {}) {
 
   const all = await Schema.fetchConsignes(ctx.db, ctx.user.uid, "practice");
   const consignes = all.filter((c) => (c.category || "") === currentCat);
-  L.info("screen.practice.consignes", consignes.length);
+  logger.info("screen.practice.consignes", consignes.length);
 
   const orderSorted = consignes.slice().sort((a, b) => {
     const orderA = Number(a.order || 0);
@@ -876,7 +876,7 @@ async function renderPractice(ctx, root, _opts = {}) {
       saveBtn.textContent = "Enregistrer";
     }
   };
-  L.groupEnd();
+  logger.groupEnd();
 }
 
 const DOW = ["DIM","LUN","MAR","MER","JEU","VEN","SAM"];
@@ -917,7 +917,7 @@ async function renderDaily(ctx, root, opts = {}) {
   const isoDay = explicitDate ? DOW[explicitDate.getDay()] : null;
   const requested = normalizeDay(opts.day) || normalizeDay(qp.get("day")) || isoDay;
   const currentDay = requested || jours[todayIdx];
-  L.group("screen.daily.render", { hash: ctx.route, day: currentDay, date: explicitDate?.toISOString?.() });
+  logger.group("screen.daily.render", { hash: ctx.route, day: currentDay, date: explicitDate?.toISOString?.() });
 
   const card = document.createElement("section");
   card.className = "card p-4 space-y-4";
@@ -957,7 +957,7 @@ async function renderDaily(ctx, root, opts = {}) {
 
   const all = await Schema.fetchConsignes(ctx.db, ctx.user.uid, "daily");
   const consignes = all.filter((c) => !c.days?.length || c.days.includes(currentDay));
-  L.info("screen.daily.consignes", consignes.length);
+  logger.info("screen.daily.consignes", consignes.length);
 
   const selectedDate = explicitDate ? new Date(explicitDate) : dateForDayFromToday(currentDay);
   const visible = [];
@@ -1117,7 +1117,7 @@ async function renderDaily(ctx, root, opts = {}) {
     $$("input[type=radio]", form).forEach((input) => (input.checked = false));
   };
 
-  L.groupEnd();
+  logger.groupEnd();
 }
 
 function renderHistory() {}


### PR DESCRIPTION
## Summary
- switch goals and modes modules to use a module-scoped `logger` variable instead of redeclaring the global `const L`
- update all logger calls to reference the new name, preventing `Identifier 'L' has already been declared` errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d294469e2c83338263f31bb9a5b0a2