### PR TITLE
Give feature scripts distinct logger bindings

### DIFF
--- a/goals.js
+++ b/goals.js
@@ -1,7 +1,7 @@
 // goals.js — Objectifs timeline
 /* global Schema, Goals */
 window.Goals = window.Goals || {};
-const L = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+const goalsLogger = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
 
 let lastMount = null;
 
@@ -106,7 +106,7 @@ async function renderGoals(ctx, root) {
         row.style.outline = "2px solid #86efac";
         setTimeout(() => { row.style.outline = "none"; }, 600);
       } catch (err) {
-        L.error("goals.quickEntry.error", err);
+        goalsLogger.error("goals.quickEntry.error", err);
         row.style.outline = "2px solid #fca5a5";
         setTimeout(() => { row.style.outline = "none"; }, 800);
       }
@@ -152,7 +152,7 @@ async function renderGoals(ctx, root) {
     try {
       goals = await Schema.listObjectivesByMonth(ctx.db, ctx.user.uid, monthKey);
     } catch (err) {
-      L.error("goals.month.load", err);
+      goalsLogger.error("goals.month.load", err);
     }
 
     goals.sort((a, b) => (a.titre || "").localeCompare(b.titre || ""));
@@ -315,7 +315,7 @@ function openGoalForm(ctx, goal = null) {
         renderGoals(ctx, lastMount);
       }
     } catch (err) {
-      L.error("goals.save.error", err);
+      goalsLogger.error("goals.save.error", err);
       alert("Impossible d'enregistrer l’objectif.");
     }
   });

--- a/schema.js
+++ b/schema.js
@@ -97,7 +97,7 @@ const D = {
   groupEnd: () => D.on && console.groupEnd(),
 };
 Schema.D = Schema.D || D;
-const log = () => {};
+const schemaLog = () => {};
 // --- Helpers de chemin /u/{uid}/...
 
 let boundDb = null;
@@ -440,7 +440,7 @@ async function softDeleteConsigne(db, uid, id) {
 }
 
 async function saveResponse(db, uid, consigne, value) {
-  log("saveResponse:start", { uid, consigneId: consigne.id, mode: consigne.mode, value });
+  schemaLog("saveResponse:start", { uid, consigneId: consigne.id, mode: consigne.mode, value });
   const payload = {
     ownerUid: uid,
     consigneId: consigne.id,
@@ -449,11 +449,11 @@ async function saveResponse(db, uid, consigne, value) {
     createdAt: now(),
   };
   const ref = await addDoc(col(db, uid, "responses"), payload);
-  log("saveResponse:done", { uid, responseId: ref.id, consigneId: consigne.id });
+  schemaLog("saveResponse:done", { uid, responseId: ref.id, consigneId: consigne.id });
 }
 
 async function fetchHistory(db, uid, count = 200) {
-  log("fetchHistory:start", { uid, count });
+  schemaLog("fetchHistory:start", { uid, count });
   const qy = query(
     col(db, uid, "responses"),
     orderBy("createdAt", "desc"),
@@ -461,7 +461,7 @@ async function fetchHistory(db, uid, count = 200) {
   );
   const ss = await getDocs(qy);
   const data = ss.docs.map(d => d.data());
-  log("fetchHistory:done", { uid, count: data.length });
+  schemaLog("fetchHistory:done", { uid, count: data.length });
   return data;
 }
 


### PR DESCRIPTION
## Summary
- rename the feature logger bindings in goals.js and modes.js so each script keeps its own unique global name
- rename the app bootstrapper's debug helper to avoid clashing with schema.js and keep the schema debug helper internal
- update all call sites to use the new helper names so the feature scripts load without identifier redeclaration errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d294469e2c83338263f31bb9a5b0a2