### PR TITLE
Fix duplicate identifier errors by isolating front-end globals

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,635 +1,641 @@
 // app.js — bootstrapping, routing, context, nav
 /* global Schema, Modes, Goals */
-const appFirestore = Schema.firestore || window.firestoreAPI || {};
-
-const firebaseCompatApp = window.firebase || {};
-
-// --- feature flags & logger ---
-const DEBUG = false;
-const LOG = DEBUG;
-const L = Schema.D || {
-  on: false,
-  info: () => {},
-  debug: () => {},
-  warn: () => {},
-  error: () => {},
-  group: () => {},
-  groupEnd: () => {},
-};
-if (L) L.on = DEBUG;
-const appLog = (...args) => { if (LOG) console.debug("[app]", ...args); };
-function logStep(step, data) {
-  L.group(step);
-  if (data) L.info(data);
-  L.groupEnd();
-}
-
-const ctx = {
-  app: null,
-  db: null,
-  user: null, // { uid } passed by index.html
-  profile: null, // profile doc
-  categories: [],
-  route: "#/admin",
-};
-
-async function refreshUserBadge(uid) {
-  const el = document.querySelector("[data-username]");
-  if (!el) return;
-  const { segments } = parseHash(ctx.route || location.hash || "#/admin");
-  const routeKey = segments[0] || "admin";
-  const isAdminRoute = routeKey === "admin";
-
-  if (isAdminRoute) {
-    el.textContent = "Admin";
+(() => {
+  if (window.__APP_ROUTER_INITIALIZED__) {
     return;
   }
+  window.__APP_ROUTER_INITIALIZED__ = true;
+  const appFirestore = Schema.firestore || window.firestoreAPI || {};
 
-  if (!uid) {
-    el.textContent = "Utilisateur";
-    return;
-  }
-  el.textContent = "…";
-  try {
-    el.textContent = await Schema.getUserName(uid);
-  } catch (err) {
-    console.warn("refreshUserBadge", err);
-    el.textContent = "Utilisateur";
-  }
-}
+  const firebaseCompatApp = window.firebase || {};
 
-function $(sel) {
-  return document.querySelector(sel);
-}
-
-function $$(sel) {
-  return Array.from(document.querySelectorAll(sel));
-}
-
-function getAuthInstance() {
-  if (!firebaseCompatApp || typeof firebaseCompatApp.auth !== "function") return null;
-  try {
-    return ctx.app ? firebaseCompatApp.auth(ctx.app) : firebaseCompatApp.auth();
-  } catch (err) {
-    console.warn("firebase.auth() fallback", err);
-    return firebaseCompatApp.auth();
-  }
-}
-
-let authInitPromise = null;
-let signInPromise = null;
-
-async function ensureSignedIn() {
-  const auth = getAuthInstance();
-  if (!auth) return null;
-  if (auth.currentUser) return auth.currentUser;
-
-  if (!authInitPromise) {
-    authInitPromise = new Promise((resolve) => {
-      const unsubscribe = auth.onAuthStateChanged((user) => {
-        unsubscribe();
-        resolve(user);
-      });
-    }).finally(() => {
-      authInitPromise = null;
-    });
-  }
-
-  const existing = await authInitPromise;
-  if (existing) return existing;
-
-  if (!signInPromise) {
-    signInPromise = auth
-      .signInAnonymously()
-      .then((cred) => cred.user)
-      .finally(() => {
-        signInPromise = null;
-      });
-  }
-
-  return signInPromise;
-}
-
-function routeTo(hash) {
-  // hash like "#/daily", "#/practice?new=1", etc.
-  if (!hash) hash = "#/admin";
-
-  // Si l'argument est déjà une URL utilisateur complète, on la prend telle quelle
-  if (/^#\/u\/[^/]+\//.test(hash)) {
-    appLog("routeTo", { from: location.hash || null, requested: hash, target: hash });
-    ctx.route = hash;
-    window.location.hash = hash;
-    render();
-    return;
-  }
-
-  // If we are currently on a user URL, prefix all routes with /u/{uid}/...
-  const m = (location.hash || "").match(/^#\/u\/([^/]+)/);
-  const base = m ? `#/u/${m[1]}/` : "#/";
-  const stayInUserSpace = m && !hash.startsWith("#/admin") && !hash.startsWith("#/u/");
-  const target = stayInUserSpace ? base + hash.replace(/^#\//, "") : hash;
-
-  appLog("routeTo", { from: location.hash || null, requested: hash, target });
-  ctx.route = target;
-  window.location.hash = target;
-  render();
-}
-window.routeTo = routeTo;
-
-function routeToDefault() {
-  if (location.hash !== "#/admin") {
-    location.hash = "#/admin";
-  } else {
-    handleRoute();
-  }
-}
-
-function setActiveNav(sectionKey) {
-  const alias = sectionKey === "dashboard" ? "daily" : sectionKey;
-  const map = {
-    admin: "#/admin",
-    daily: "#/daily",
-    practice: "#/practice",
-    goals: "#/goals",
+  // --- feature flags & logger ---
+  const DEBUG = false;
+  const LOG = DEBUG;
+  const L = Schema.D || {
+    on: false,
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+    group: () => {},
+    groupEnd: () => {},
   };
-  const activeTarget = map[alias] || "#/admin";
-  const accentSection = map[alias] ? alias : "daily";
+  if (L) L.on = DEBUG;
+  const appLog = (...args) => { if (LOG) console.debug("[app]", ...args); };
+  function logStep(step, data) {
+    L.group(step);
+    if (data) L.info(data);
+    L.groupEnd();
+  }
 
-  document.body.setAttribute("data-section", accentSection);
+  const ctx = {
+    app: null,
+    db: null,
+    user: null, // { uid } passed by index.html
+    profile: null, // profile doc
+    categories: [],
+    route: "#/admin",
+  };
 
-  $$('button[data-route]').forEach((btn) => {
-    const target = btn.getAttribute("data-route");
-    const isActive = target === activeTarget;
-    btn.setAttribute("aria-current", isActive ? "page" : "false");
-  });
-}
+  async function refreshUserBadge(uid) {
+    const el = document.querySelector("[data-username]");
+    if (!el) return;
+    const { segments } = parseHash(ctx.route || location.hash || "#/admin");
+    const routeKey = segments[0] || "admin";
+    const isAdminRoute = routeKey === "admin";
 
-function parseHash(hashValue) {
-  const hash = hashValue || "#/admin";
-  const normalized = hash.replace(/^#/, "");
-  const [pathPartRaw, searchPart = ""] = normalized.split("?");
-  const pathPart = pathPartRaw.replace(/^\/+/, "");
-  const segments = pathPart ? pathPart.split("/") : [];
-  const qp = new URLSearchParams(searchPart);
-  return { hash, segments, search: searchPart, qp };
-}
+    if (isAdminRoute) {
+      el.textContent = "Admin";
+      return;
+    }
 
-async function loadCategories() {
-  // Categories are per user, default fallback if empty
-  appLog("categories:load:start", { uid: ctx.user?.uid });
-  const uid = ctx.user.uid;
-  const cats = await Schema.fetchCategories(ctx.db, uid);
-  ctx.categories = cats;
-  appLog("categories:load:done", { count: cats.length });
-  renderSidebar();
-}
-
-function renderSidebar() {
-  const box = $("#profile-box");
-  if (!box) return;
-  appLog("sidebar:render", { profile: ctx.profile, categories: ctx.categories?.length });
-  const link = `${location.origin}${location.pathname}#/u/${ctx.user.uid}`;
-  box.innerHTML = `
-    <div><strong>${ctx.profile.displayName || "Utilisateur"}</strong></div>
-    <div class="muted">UID : <code>${ctx.user.uid}</code></div>
-    <div class="muted">Lien direct : <a class="link" href="${link}">${link}</a></div>
-  `;
-  const catBox = $("#category-box");
-  if (catBox) {
-    if (!ctx.categories.length) {
-      catBox.innerHTML = '<span class="muted">Aucune catégorie. Elles seront créées automatiquement lors de l’ajout d’une consigne.</span>';
-    } else {
-      catBox.innerHTML = ctx.categories.map(c => `<div class="flex"><span>${c.name}</span><span class="pill">${c.mode}</span></div>`).join("");
+    if (!uid) {
+      el.textContent = "Utilisateur";
+      return;
+    }
+    el.textContent = "…";
+    try {
+      el.textContent = await Schema.getUserName(uid);
+    } catch (err) {
+      console.warn("refreshUserBadge", err);
+      el.textContent = "Utilisateur";
     }
   }
-}
 
-function bindNav() {
-  // Navigation haut (Daily, Practice, etc.)
-  appLog("nav:bind:start");
-  $$("button[data-route]").forEach(btn => {
-    const target = btn.getAttribute("data-route");
-    appLog("nav:bind:button", { target });
-    btn.onclick = () => routeTo(target);
-  });
-
-  // Boutons spécifiques (seulement si présents dans le DOM)
-  const btnSession = $("#btn-new-session");
-  if (btnSession) {
-    appLog("nav:bind:newSessionButton");
-    btnSession.onclick = () => routeTo("#/practice?new=1");
+  function $(sel) {
+    return document.querySelector(sel);
   }
 
-  const btnConsigne = $("#btn-add-consigne");
-  if (btnConsigne) {
-    appLog("nav:bind:addConsigne");
-    btnConsigne.onclick = () => Modes.openConsigneForm(ctx);
+  function $$(sel) {
+    return Array.from(document.querySelectorAll(sel));
   }
 
-  const btnGoal = $("#btn-add-goal");
-  if (btnGoal) {
-    appLog("nav:bind:addGoal");
-    btnGoal.onclick = () => Goals.openGoalForm(ctx);
-  }
-}
-
-function redirectToDefaultSection() {
-  routeToDefault();
-}
-
-async function ensureOwnRoute(parsed) {
-  let desired = parsed.segments[0] || "daily";
-  if (!desired) desired = "daily";
-
-  const qp = parsed.qp || new URLSearchParams(parsed.search || "");
-  const requestedUid = qp.get("u");
-
-  let authUser;
-  try {
-    authUser = await ensureSignedIn();
-  } catch (error) {
-    if (DEBUG) console.warn("[Auth] anonymous sign-in failed", error);
+  function getAuthInstance() {
+    if (!firebaseCompatApp || typeof firebaseCompatApp.auth !== "function") return null;
+    try {
+      return ctx.app ? firebaseCompatApp.auth(ctx.app) : firebaseCompatApp.auth();
+    } catch (err) {
+      console.warn("firebase.auth() fallback", err);
+      return firebaseCompatApp.auth();
+    }
   }
 
-  const fallbackUid = authUser?.uid;
-  const targetUid = requestedUid || fallbackUid;
+  let authInitPromise = null;
+  let signInPromise = null;
 
-  if (!targetUid) {
-    redirectToDefaultSection();
-    return;
+  async function ensureSignedIn() {
+    const auth = getAuthInstance();
+    if (!auth) return null;
+    if (auth.currentUser) return auth.currentUser;
+
+    if (!authInitPromise) {
+      authInitPromise = new Promise((resolve) => {
+        const unsubscribe = auth.onAuthStateChanged((user) => {
+          unsubscribe();
+          resolve(user);
+        });
+      }).finally(() => {
+        authInitPromise = null;
+      });
+    }
+
+    const existing = await authInitPromise;
+    if (existing) return existing;
+
+    if (!signInPromise) {
+      signInPromise = auth
+        .signInAnonymously()
+        .then((cred) => cred.user)
+        .finally(() => {
+          signInPromise = null;
+        });
+    }
+
+    return signInPromise;
   }
 
-  if (requestedUid) {
-    qp.delete("u");
-  }
-  const searchPart = qp.toString();
-  const target = `#/u/${targetUid}/${desired}${searchPart ? `?${searchPart}` : ""}`;
+  function routeTo(hash) {
+    // hash like "#/daily", "#/practice?new=1", etc.
+    if (!hash) hash = "#/admin";
 
-  if (location.hash !== target) {
-    location.replace(target);
-  } else if (!ctx.user || ctx.user.uid !== targetUid) {
-    await initApp({
-      app: ctx.app,
-      db: ctx.db,
-      user: { uid: targetUid }
+    // Si l'argument est déjà une URL utilisateur complète, on la prend telle quelle
+    if (/^#\/u\/[^/]+\//.test(hash)) {
+      appLog("routeTo", { from: location.hash || null, requested: hash, target: hash });
+      ctx.route = hash;
+      window.location.hash = hash;
+      render();
+      return;
+    }
+
+    // If we are currently on a user URL, prefix all routes with /u/{uid}/...
+    const m = (location.hash || "").match(/^#\/u\/([^/]+)/);
+    const base = m ? `#/u/${m[1]}/` : "#/";
+    const stayInUserSpace = m && !hash.startsWith("#/admin") && !hash.startsWith("#/u/");
+    const target = stayInUserSpace ? base + hash.replace(/^#\//, "") : hash;
+
+    appLog("routeTo", { from: location.hash || null, requested: hash, target });
+    ctx.route = target;
+    window.location.hash = target;
+    render();
+  }
+  window.routeTo = routeTo;
+
+  function routeToDefault() {
+    if (location.hash !== "#/admin") {
+      location.hash = "#/admin";
+    } else {
+      handleRoute();
+    }
+  }
+
+  function setActiveNav(sectionKey) {
+    const alias = sectionKey === "dashboard" ? "daily" : sectionKey;
+    const map = {
+      admin: "#/admin",
+      daily: "#/daily",
+      practice: "#/practice",
+      goals: "#/goals",
+    };
+    const activeTarget = map[alias] || "#/admin";
+    const accentSection = map[alias] ? alias : "daily";
+
+    document.body.setAttribute("data-section", accentSection);
+
+    $$('button[data-route]').forEach((btn) => {
+      const target = btn.getAttribute("data-route");
+      const isActive = target === activeTarget;
+      btn.setAttribute("aria-current", isActive ? "page" : "false");
     });
   }
-}
 
-// --- Router global (admin <-> user) ---
-async function handleRoute() {
-  const currentHash = location.hash || "#/admin";
-  const parsed = parseHash(currentHash);
-  ctx.route = currentHash;
-  appLog("handleRoute", parsed);
+  function parseHash(hashValue) {
+    const hash = hashValue || "#/admin";
+    const normalized = hash.replace(/^#/, "");
+    const [pathPartRaw, searchPart = ""] = normalized.split("?");
+    const pathPart = pathPartRaw.replace(/^\/+/, "");
+    const segments = pathPart ? pathPart.split("/") : [];
+    const qp = new URLSearchParams(searchPart);
+    return { hash, segments, search: searchPart, qp };
+  }
 
-  const routeName = parsed.segments[0] || "admin";
+  async function loadCategories() {
+    // Categories are per user, default fallback if empty
+    appLog("categories:load:start", { uid: ctx.user?.uid });
+    const uid = ctx.user.uid;
+    const cats = await Schema.fetchCategories(ctx.db, uid);
+    ctx.categories = cats;
+    appLog("categories:load:done", { count: cats.length });
+    renderSidebar();
+  }
 
-  if (routeName === "admin") {
+  function renderSidebar() {
+    const box = $("#profile-box");
+    if (!box) return;
+    appLog("sidebar:render", { profile: ctx.profile, categories: ctx.categories?.length });
+    const link = `${location.origin}${location.pathname}#/u/${ctx.user.uid}`;
+    box.innerHTML = `
+      <div><strong>${ctx.profile.displayName || "Utilisateur"}</strong></div>
+      <div class="muted">UID : <code>${ctx.user.uid}</code></div>
+      <div class="muted">Lien direct : <a class="link" href="${link}">${link}</a></div>
+    `;
+    const catBox = $("#category-box");
+    if (catBox) {
+      if (!ctx.categories.length) {
+        catBox.innerHTML = '<span class="muted">Aucune catégorie. Elles seront créées automatiquement lors de l’ajout d’une consigne.</span>';
+      } else {
+        catBox.innerHTML = ctx.categories.map(c => `<div class="flex"><span>${c.name}</span><span class="pill">${c.mode}</span></div>`).join("");
+      }
+    }
+  }
+
+  function bindNav() {
+    // Navigation haut (Daily, Practice, etc.)
+    appLog("nav:bind:start");
+    $$("button[data-route]").forEach(btn => {
+      const target = btn.getAttribute("data-route");
+      appLog("nav:bind:button", { target });
+      btn.onclick = () => routeTo(target);
+    });
+
+    // Boutons spécifiques (seulement si présents dans le DOM)
+    const btnSession = $("#btn-new-session");
+    if (btnSession) {
+      appLog("nav:bind:newSessionButton");
+      btnSession.onclick = () => routeTo("#/practice?new=1");
+    }
+
+    const btnConsigne = $("#btn-add-consigne");
+    if (btnConsigne) {
+      appLog("nav:bind:addConsigne");
+      btnConsigne.onclick = () => Modes.openConsigneForm(ctx);
+    }
+
+    const btnGoal = $("#btn-add-goal");
+    if (btnGoal) {
+      appLog("nav:bind:addGoal");
+      btnGoal.onclick = () => Goals.openGoalForm(ctx);
+    }
+  }
+
+  function redirectToDefaultSection() {
+    routeToDefault();
+  }
+
+  async function ensureOwnRoute(parsed) {
+    let desired = parsed.segments[0] || "daily";
+    if (!desired) desired = "daily";
+
+    const qp = parsed.qp || new URLSearchParams(parsed.search || "");
+    const requestedUid = qp.get("u");
+
+    let authUser;
     try {
-      await ensureSignedIn();
+      authUser = await ensureSignedIn();
     } catch (error) {
       if (DEBUG) console.warn("[Auth] anonymous sign-in failed", error);
     }
-    render();
-    return;
-  }
 
-  if (routeName === "u") {
-    const qp = parsed.qp || new URLSearchParams(parsed.search || "");
-    const uid = parsed.segments[1];
-    let section = parsed.segments[2];
-    const requestedUid = qp.get("u");
-    const targetUid = requestedUid || uid;
+    const fallbackUid = authUser?.uid;
+    const targetUid = requestedUid || fallbackUid;
 
     if (!targetUid) {
       redirectToDefaultSection();
       return;
     }
 
-    if (!section) {
-      if (requestedUid) qp.delete("u");
-      const searchPart = qp.toString();
-      const target = `#/u/${targetUid}/daily${searchPart ? `?${searchPart}` : ""}`;
-      location.replace(target);
-      return;
-    }
-
-    if (requestedUid && requestedUid !== uid) {
+    if (requestedUid) {
       qp.delete("u");
-      const searchPart = qp.toString();
-      const target = `#/u/${targetUid}/${section}${searchPart ? `?${searchPart}` : ""}`;
+    }
+    const searchPart = qp.toString();
+    const target = `#/u/${targetUid}/${desired}${searchPart ? `?${searchPart}` : ""}`;
+
+    if (location.hash !== target) {
       location.replace(target);
-      return;
-    }
-
-    if (ctx.user?.uid === targetUid) {
-      return;
-    }
-
-    await initApp({
-      app: ctx.app,
-      db: ctx.db,
-      user: {
-        uid: targetUid
-      }
-    });
-    return;
-  }
-
-  await ensureOwnRoute(parsed);
-}
-
-function startRouter(app, db) {
-  // We keep app/db in the context for the screens
-  appLog("router:start", { hash: location.hash });
-  ctx.app = app;
-  ctx.db = db;
-  if (typeof Schema.bindDb === "function") Schema.bindDb(db);
-  bindNav();
-  if (!location.hash || location.hash === "#") {
-    routeToDefault();
-  } else {
-    handleRoute(); // initial render
-  }
-  window.addEventListener("hashchange", () => {
-    appLog("router:hashchange", { hash: location.hash });
-    handleRoute();
-  }); // navigation
-}
-
-// Local ensureProfile function
-async function ensureProfile(db, uid) {
-  appLog("profile:ensure:start", { uid });
-  const ref = appFirestore.doc(db, "u", uid);
-  const snap = await appFirestore.getDoc(ref);
-  if (snap.exists()) {
-    const data = snap.data();
-    appLog("profile:ensure:existing", { uid });
-    return data;
-  }
-  const newProfile = {
-    displayName: "Nouvel utilisateur",
-    createdAt: new Date().toISOString()
-  };
-  await appFirestore.setDoc(ref, newProfile);
-  appLog("profile:ensure:created", { uid });
-  return newProfile;
-}
-
-async function ensurePushSubscription(ctx) {
-  const messagingSupported = typeof firebaseCompatApp?.messaging?.isSupported === "function"
-    ? firebaseCompatApp.messaging.isSupported()
-    : Promise.resolve(false);
-  if (!(await messagingSupported)) { console.info("[push] non supporté"); return; }
-  if (!("Notification" in window) || !("serviceWorker" in navigator)) return;
-
-  // 1) Permission
-  let perm = Notification.permission;
-  if (perm === "default") perm = await Notification.requestPermission();
-  if (perm !== "granted") { console.info("[push] permission refusée"); return; }
-
-  // 2) Enregistrer le SW *avec un chemin relatif fiable sur GitHub Pages*
-  const basePath = `${window.location.origin}${window.location.pathname.replace(/[^/]*$/, '')}`;
-  const swUrl = new URL("sw.js", basePath);
-  const reg = await navigator.serviceWorker.register(swUrl.href, { scope: "./" });
-  console.info("[push] SW OK", reg.scope);
-
-  // 3) Token FCM avec TA clé VAPID publique
-  let messaging;
-  try {
-    messaging = ctx.app ? firebaseCompatApp.messaging(ctx.app) : firebaseCompatApp.messaging();
-  } catch (err) {
-    console.info("[push] messaging non disponible", err);
-    return;
-  }
-  const token = await messaging.getToken({
-    vapidKey: "BMKhViKlpYs9dtqHYQYIU9rmTJQA3rPUP2h5Mg1YlA6lUs4uHk74F8rT9y8hT1U2N4M-UUE7-YvbAjYfTpjA1nM",
-    serviceWorkerRegistration: reg
-  });
-  if (!token) { console.warn("[push] pas de token"); return; }
-  console.info("[push] token", token);
-
-  // 4) Enregistrer le token côté Firestore
-  await Schema.savePushToken(ctx.db, ctx.user.uid, token);
-
-  // 5) Réception en foreground
-  messaging.onMessage((payload) => {
-    try {
-      new Notification(payload?.notification?.title || "Rappel", {
-        body: payload?.notification?.body || "Tu as des consignes à remplir aujourd’hui.",
-        icon: "/icon.png"
+    } else if (!ctx.user || ctx.user.uid !== targetUid) {
+      await initApp({
+        app: ctx.app,
+        db: ctx.db,
+        user: { uid: targetUid }
       });
-    } catch {}
-  });
-}
-
-async function initApp({ app, db, user }) {
-  // Show the sidebar in user mode
-  const sidebar = document.getElementById("sidebar");
-  if (sidebar) sidebar.style.display = "";
-
-  L.group("app.init", user?.uid);
-  appLog("app:init:start", { uid: user?.uid });
-  if (!user || !user.uid) {
-    L.error("No UID in context");
-    appLog("app:init:error", { reason: "missing uid" });
-    L.groupEnd();
-    return;
+    }
   }
-  ctx.app = app;
-  ctx.db = db;
-  ctx.user = user;
 
-  await refreshUserBadge(user.uid);
+  // --- Router global (admin <-> user) ---
+  async function handleRoute() {
+    const currentHash = location.hash || "#/admin";
+    const parsed = parseHash(currentHash);
+    ctx.route = currentHash;
+    appLog("handleRoute", parsed);
 
-  const profile = await ensureProfile(db, user.uid);
-  ctx.profile = profile;
-  appLog("app:init:profile", { profile });
+    const routeName = parsed.segments[0] || "admin";
 
-  // Display profile in the sidebar
-  const box = document.getElementById("profile-box");
-  if (box) box.innerHTML = `<div><b>UID:</b> ${user.uid}<br><span class="muted">Profil chargé.</span></div>`;
-
-  await loadCategories();
-  bindNav();
-
-  ctx.route = location.hash || "#/admin";
-  appLog("app:init:route", { route: ctx.route });
-  window.addEventListener("hashchange", () => {
-    ctx.route = location.hash || "#/admin";
-    appLog("app:init:hashchange", { route: ctx.route });
-    render();
-  });
-  await render();
-  // 👉 Inscription (silencieuse si refus/unsupported)
-  ensurePushSubscription(ctx).catch(console.error);
-  appLog("app:init:rendered");
-  L.groupEnd();
-}
-
-function newUid() {
-  // Simple, readable, unique UID
-  return "u-" + Math.random().toString(36).slice(2, 10);
-}
-
-function renderAdmin(db) {
-  // Hide the sidebar in admin mode
-  const sidebar = document.getElementById("sidebar");
-  if (sidebar) sidebar.style.display = "none";
-
-  refreshUserBadge(null);
-
-  const root = document.getElementById("view-root");
-  appLog("admin:render");
-  root.innerHTML = `
-    <div class="space-y-4">
-      <h2 class="text-xl font-semibold">Admin — Utilisateurs</h2>
-      <form id="new-user-form" class="card p-4 space-y-3 max-w-md">
-        <input type="text" id="new-user-name" placeholder="Nom de l’utilisateur" required class="w-full" />
-        <button class="btn btn-primary" type="submit">Créer l’utilisateur</button>
-      </form>
-      <div class="card p-4 space-y-3">
-        <div class="font-semibold">Utilisateurs existants</div>
-        <div id="user-list" class="grid gap-3"></div>
-      </div>
-    </div>
-  `;
-
-  const form = document.getElementById("new-user-form");
-  if (form) {
-    form.addEventListener("submit", async(e) => {
-      e.preventDefault();
-      const input = document.getElementById("new-user-name");
-      const name = input?.value?.trim();
-      if (!name) return;
-      appLog("admin:newUser:submit", { name });
-      const uid = newUid();
+    if (routeName === "admin") {
       try {
-        await appFirestore.setDoc(appFirestore.doc(db, "u", uid), {
-          displayName: name,
-          createdAt: new Date().toISOString()
-        });
-        if (input) input.value = "";
-        appLog("admin:newUser:created", { uid });
-        loadUsers(db);
+        await ensureSignedIn();
       } catch (error) {
-        console.error("admin:newUser:error", error);
-        alert("Création impossible. Réessaie plus tard.");
+        if (DEBUG) console.warn("[Auth] anonymous sign-in failed", error);
       }
-    });
-  }
+      render();
+      return;
+    }
 
-  loadUsers(db);
-}
+    if (routeName === "u") {
+      const qp = parsed.qp || new URLSearchParams(parsed.search || "");
+      const uid = parsed.segments[1];
+      let section = parsed.segments[2];
+      const requestedUid = qp.get("u");
+      const targetUid = requestedUid || uid;
 
-async function loadUsers(db) {
-  const list = document.getElementById("user-list");
-  if (!list) return;
-  list.innerHTML = "<div class='text-sm text-[var(--muted)]'>Chargement…</div>";
-  appLog("admin:users:load:start");
-  try {
-    const ss = await appFirestore.getDocs(appFirestore.collection(db, "u"));
-    const items = [];
-    ss.forEach(d => {
-      const data = d.data();
-      const uid = d.id;
-      const link = `${location.origin}${location.pathname}#/u/${uid}/daily`;
-      items.push(`
-        <div class="flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white p-3">
-          <div>
-            <div class="font-medium">${data.displayName || "(sans nom)"}</div>
-            <div class="text-sm text-[var(--muted)]">UID: ${uid}</div>
-          </div>
-          <a class="btn btn-ghost text-sm"
-             href="${link}"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-uid="${uid}">Ouvrir</a>
-        </div>
-      `);
-    });
-    list.innerHTML = items.join("") || "<div class='text-sm text-[var(--muted)]'>Aucun utilisateur</div>";
-    appLog("admin:users:load:done", { count: items.length });
+      if (!targetUid) {
+        redirectToDefaultSection();
+        return;
+      }
 
-    if (!list.dataset.bound) {
-      list.addEventListener("click", (e) => {
-        const a = e.target.closest("a[data-uid]");
-        if (!a) return;
-        if (!a.target || a.target === "_self") {
-          e.preventDefault();
-          location.hash = `#/u/${a.dataset.uid}`;
-          appLog("admin:users:navigate", { uid: a.dataset.uid });
-          handleRoute();
+      if (!section) {
+        if (requestedUid) qp.delete("u");
+        const searchPart = qp.toString();
+        const target = `#/u/${targetUid}/daily${searchPart ? `?${searchPart}` : ""}`;
+        location.replace(target);
+        return;
+      }
+
+      if (requestedUid && requestedUid !== uid) {
+        qp.delete("u");
+        const searchPart = qp.toString();
+        const target = `#/u/${targetUid}/${section}${searchPart ? `?${searchPart}` : ""}`;
+        location.replace(target);
+        return;
+      }
+
+      if (ctx.user?.uid === targetUid) {
+        return;
+      }
+
+      await initApp({
+        app: ctx.app,
+        db: ctx.db,
+        user: {
+          uid: targetUid
         }
       });
-      list.dataset.bound = "1";
+      return;
     }
-  } catch (error) {
-    console.warn("admin:users:load:error", error);
-    list.innerHTML = "<div class='text-sm text-red-600'>Impossible de charger les utilisateurs.</div>";
-  }
-}
 
-function renderUser(db, uid) {
-  initApp({
-    app: ctx.app,
-    db,
-    user: {
-      uid
+    await ensureOwnRoute(parsed);
+  }
+
+  function startRouter(app, db) {
+    // We keep app/db in the context for the screens
+    appLog("router:start", { hash: location.hash });
+    ctx.app = app;
+    ctx.db = db;
+    if (typeof Schema.bindDb === "function") Schema.bindDb(db);
+    bindNav();
+    if (!location.hash || location.hash === "#") {
+      routeToDefault();
+    } else {
+      handleRoute(); // initial render
     }
-  });
-}
-
-function render() {
-  const root = document.getElementById("view-root");
-  if (!root) return;
-
-  root.classList.remove("route-enter");
-  // eslint-disable-next-line no-unused-expressions
-  root.offsetHeight;
-  root.classList.add("route-enter");
-
-  const h = ctx.route || location.hash || "#/admin";
-  const tokens = h.replace(/^#\//, "").split("/"); // ["u","{uid}","daily?day=mon"] ou ["daily?..."]
-
-  let section = tokens[0];
-  let sub = null;
-  if (section === "u") {
-    // /u/{uid}/{sub}
-    const uid = tokens[1];
-    sub = (tokens[2] || "daily");
-    // IMPORTANT: enlever la query de 'sub'
-    sub = sub.split("?")[0];
-    ctx.user = { uid };
-  } else {
-    ctx.user = null;
+    window.addEventListener("hashchange", () => {
+      appLog("router:hashchange", { hash: location.hash });
+      handleRoute();
+    }); // navigation
   }
 
-  // Query params (toujours depuis l'URL complète)
-  const qp = new URLSearchParams((h.split("?")[1] || ""));
-
-  const currentSection = section === "u" ? sub : section;
-  setActiveNav(currentSection);
-
-  switch (currentSection) {
-    case "admin":
-      return renderAdmin(ctx.db);
-    case "dashboard":
-    case "daily":
-      return Modes.renderDaily(ctx, root, { day: qp.get("day"), dateIso: qp.get("d") });
-    case "practice":
-      return Modes.renderPractice(ctx, root, { newSession: qp.get("new") === "1" });
-    case "history":
-      return Modes.renderHistory(ctx, root);
-    case "goals":
-      return Goals.renderGoals(ctx, root);
-    default:
-      root.innerHTML = "<div class='card'>Page inconnue.</div>";
+  // Local ensureProfile function
+  async function ensureProfile(db, uid) {
+    appLog("profile:ensure:start", { uid });
+    const ref = appFirestore.doc(db, "u", uid);
+    const snap = await appFirestore.getDoc(ref);
+    if (snap.exists()) {
+      const data = snap.data();
+      appLog("profile:ensure:existing", { uid });
+      return data;
+    }
+    const newProfile = {
+      displayName: "Nouvel utilisateur",
+      createdAt: new Date().toISOString()
+    };
+    await appFirestore.setDoc(ref, newProfile);
+    appLog("profile:ensure:created", { uid });
+    return newProfile;
   }
-}
 
-window.AppCtx = ctx;
-window.startRouter = startRouter;
-window.initApp = initApp;
-window.renderAdmin = renderAdmin;
+  async function ensurePushSubscription(ctx) {
+    const messagingSupported = typeof firebaseCompatApp?.messaging?.isSupported === "function"
+      ? firebaseCompatApp.messaging.isSupported()
+      : Promise.resolve(false);
+    if (!(await messagingSupported)) { console.info("[push] non supporté"); return; }
+    if (!("Notification" in window) || !("serviceWorker" in navigator)) return;
+
+    // 1) Permission
+    let perm = Notification.permission;
+    if (perm === "default") perm = await Notification.requestPermission();
+    if (perm !== "granted") { console.info("[push] permission refusée"); return; }
+
+    // 2) Enregistrer le SW *avec un chemin relatif fiable sur GitHub Pages*
+    const basePath = `${window.location.origin}${window.location.pathname.replace(/[^/]*$/, '')}`;
+    const swUrl = new URL("sw.js", basePath);
+    const reg = await navigator.serviceWorker.register(swUrl.href, { scope: "./" });
+    console.info("[push] SW OK", reg.scope);
+
+    // 3) Token FCM avec TA clé VAPID publique
+    let messaging;
+    try {
+      messaging = ctx.app ? firebaseCompatApp.messaging(ctx.app) : firebaseCompatApp.messaging();
+    } catch (err) {
+      console.info("[push] messaging non disponible", err);
+      return;
+    }
+    const token = await messaging.getToken({
+      vapidKey: "BMKhViKlpYs9dtqHYQYIU9rmTJQA3rPUP2h5Mg1YlA6lUs4uHk74F8rT9y8hT1U2N4M-UUE7-YvbAjYfTpjA1nM",
+      serviceWorkerRegistration: reg
+    });
+    if (!token) { console.warn("[push] pas de token"); return; }
+    console.info("[push] token", token);
+
+    // 4) Enregistrer le token côté Firestore
+    await Schema.savePushToken(ctx.db, ctx.user.uid, token);
+
+    // 5) Réception en foreground
+    messaging.onMessage((payload) => {
+      try {
+        new Notification(payload?.notification?.title || "Rappel", {
+          body: payload?.notification?.body || "Tu as des consignes à remplir aujourd’hui.",
+          icon: "/icon.png"
+        });
+      } catch {}
+    });
+  }
+
+  async function initApp({ app, db, user }) {
+    // Show the sidebar in user mode
+    const sidebar = document.getElementById("sidebar");
+    if (sidebar) sidebar.style.display = "";
+
+    L.group("app.init", user?.uid);
+    appLog("app:init:start", { uid: user?.uid });
+    if (!user || !user.uid) {
+      L.error("No UID in context");
+      appLog("app:init:error", { reason: "missing uid" });
+      L.groupEnd();
+      return;
+    }
+    ctx.app = app;
+    ctx.db = db;
+    ctx.user = user;
+
+    await refreshUserBadge(user.uid);
+
+    const profile = await ensureProfile(db, user.uid);
+    ctx.profile = profile;
+    appLog("app:init:profile", { profile });
+
+    // Display profile in the sidebar
+    const box = document.getElementById("profile-box");
+    if (box) box.innerHTML = `<div><b>UID:</b> ${user.uid}<br><span class="muted">Profil chargé.</span></div>`;
+
+    await loadCategories();
+    bindNav();
+
+    ctx.route = location.hash || "#/admin";
+    appLog("app:init:route", { route: ctx.route });
+    window.addEventListener("hashchange", () => {
+      ctx.route = location.hash || "#/admin";
+      appLog("app:init:hashchange", { route: ctx.route });
+      render();
+    });
+    await render();
+    // 👉 Inscription (silencieuse si refus/unsupported)
+    ensurePushSubscription(ctx).catch(console.error);
+    appLog("app:init:rendered");
+    L.groupEnd();
+  }
+
+  function newUid() {
+    // Simple, readable, unique UID
+    return "u-" + Math.random().toString(36).slice(2, 10);
+  }
+
+  function renderAdmin(db) {
+    // Hide the sidebar in admin mode
+    const sidebar = document.getElementById("sidebar");
+    if (sidebar) sidebar.style.display = "none";
+
+    refreshUserBadge(null);
+
+    const root = document.getElementById("view-root");
+    appLog("admin:render");
+    root.innerHTML = `
+      <div class="space-y-4">
+        <h2 class="text-xl font-semibold">Admin — Utilisateurs</h2>
+        <form id="new-user-form" class="card p-4 space-y-3 max-w-md">
+          <input type="text" id="new-user-name" placeholder="Nom de l’utilisateur" required class="w-full" />
+          <button class="btn btn-primary" type="submit">Créer l’utilisateur</button>
+        </form>
+        <div class="card p-4 space-y-3">
+          <div class="font-semibold">Utilisateurs existants</div>
+          <div id="user-list" class="grid gap-3"></div>
+        </div>
+      </div>
+    `;
+
+    const form = document.getElementById("new-user-form");
+    if (form) {
+      form.addEventListener("submit", async(e) => {
+        e.preventDefault();
+        const input = document.getElementById("new-user-name");
+        const name = input?.value?.trim();
+        if (!name) return;
+        appLog("admin:newUser:submit", { name });
+        const uid = newUid();
+        try {
+          await appFirestore.setDoc(appFirestore.doc(db, "u", uid), {
+            displayName: name,
+            createdAt: new Date().toISOString()
+          });
+          if (input) input.value = "";
+          appLog("admin:newUser:created", { uid });
+          loadUsers(db);
+        } catch (error) {
+          console.error("admin:newUser:error", error);
+          alert("Création impossible. Réessaie plus tard.");
+        }
+      });
+    }
+
+    loadUsers(db);
+  }
+
+  async function loadUsers(db) {
+    const list = document.getElementById("user-list");
+    if (!list) return;
+    list.innerHTML = "<div class='text-sm text-[var(--muted)]'>Chargement…</div>";
+    appLog("admin:users:load:start");
+    try {
+      const ss = await appFirestore.getDocs(appFirestore.collection(db, "u"));
+      const items = [];
+      ss.forEach(d => {
+        const data = d.data();
+        const uid = d.id;
+        const link = `${location.origin}${location.pathname}#/u/${uid}/daily`;
+        items.push(`
+          <div class="flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white p-3">
+            <div>
+              <div class="font-medium">${data.displayName || "(sans nom)"}</div>
+              <div class="text-sm text-[var(--muted)]">UID: ${uid}</div>
+            </div>
+            <a class="btn btn-ghost text-sm"
+               href="${link}"
+               target="_blank"
+               rel="noopener noreferrer"
+               data-uid="${uid}">Ouvrir</a>
+          </div>
+        `);
+      });
+      list.innerHTML = items.join("") || "<div class='text-sm text-[var(--muted)]'>Aucun utilisateur</div>";
+      appLog("admin:users:load:done", { count: items.length });
+
+      if (!list.dataset.bound) {
+        list.addEventListener("click", (e) => {
+          const a = e.target.closest("a[data-uid]");
+          if (!a) return;
+          if (!a.target || a.target === "_self") {
+            e.preventDefault();
+            location.hash = `#/u/${a.dataset.uid}`;
+            appLog("admin:users:navigate", { uid: a.dataset.uid });
+            handleRoute();
+          }
+        });
+        list.dataset.bound = "1";
+      }
+    } catch (error) {
+      console.warn("admin:users:load:error", error);
+      list.innerHTML = "<div class='text-sm text-red-600'>Impossible de charger les utilisateurs.</div>";
+    }
+  }
+
+  function renderUser(db, uid) {
+    initApp({
+      app: ctx.app,
+      db,
+      user: {
+        uid
+      }
+    });
+  }
+
+  function render() {
+    const root = document.getElementById("view-root");
+    if (!root) return;
+
+    root.classList.remove("route-enter");
+    // eslint-disable-next-line no-unused-expressions
+    root.offsetHeight;
+    root.classList.add("route-enter");
+
+    const h = ctx.route || location.hash || "#/admin";
+    const tokens = h.replace(/^#\//, "").split("/"); // ["u","{uid}","daily?day=mon"] ou ["daily?..."]
+
+    let section = tokens[0];
+    let sub = null;
+    if (section === "u") {
+      // /u/{uid}/{sub}
+      const uid = tokens[1];
+      sub = (tokens[2] || "daily");
+      // IMPORTANT: enlever la query de 'sub'
+      sub = sub.split("?")[0];
+      ctx.user = { uid };
+    } else {
+      ctx.user = null;
+    }
+
+    // Query params (toujours depuis l'URL complète)
+    const qp = new URLSearchParams((h.split("?")[1] || ""));
+
+    const currentSection = section === "u" ? sub : section;
+    setActiveNav(currentSection);
+
+    switch (currentSection) {
+      case "admin":
+        return renderAdmin(ctx.db);
+      case "dashboard":
+      case "daily":
+        return Modes.renderDaily(ctx, root, { day: qp.get("day"), dateIso: qp.get("d") });
+      case "practice":
+        return Modes.renderPractice(ctx, root, { newSession: qp.get("new") === "1" });
+      case "history":
+        return Modes.renderHistory(ctx, root);
+      case "goals":
+        return Goals.renderGoals(ctx, root);
+      default:
+        root.innerHTML = "<div class='card'>Page inconnue.</div>";
+    }
+  }
+
+  window.AppCtx = ctx;
+  window.startRouter = startRouter;
+  window.initApp = initApp;
+  window.renderAdmin = renderAdmin;
+})();

--- a/goals.js
+++ b/goals.js
@@ -1,325 +1,331 @@
 // goals.js — Objectifs timeline
 /* global Schema, Goals */
-window.Goals = window.Goals || {};
-const goalsLogger = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
-
-let lastMount = null;
-
-function escapeHtml(str) {
-  return String(str ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function monthShift(monthKey, offset) {
-  const [year, month] = monthKey.split("-").map(Number);
-  const base = new Date(year || 1970, (month || 1) - 1 + offset, 1);
-  return Schema.monthKeyFromDate(base);
-}
-
-function typeLabel(goal) {
-  if (goal.type === "hebdo") {
-    return `Semaine ${goal.weekOfMonth || "?"}`;
+(() => {
+  const GoalsNS = (window.Goals = window.Goals || {});
+  if (GoalsNS.__initialized) {
+    return;
   }
-  if (goal.type === "mensuel") {
-    return "Mensuel";
+  GoalsNS.__initialized = true;
+  const goalsLogger = Schema.D || { info: () => {}, group: () => {}, groupEnd: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+
+  let lastMount = null;
+
+  function escapeHtml(str) {
+    return String(str ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   }
-  return goal.type || "Objectif";
-}
 
-async function renderGoals(ctx, root) {
-  lastMount = root;
-  root.innerHTML = "";
+  function monthShift(monthKey, offset) {
+    const [year, month] = monthKey.split("-").map(Number);
+    const base = new Date(year || 1970, (month || 1) - 1 + offset, 1);
+    return Schema.monthKeyFromDate(base);
+  }
 
-  const section = document.createElement("section");
-  section.className = "card";
-  section.style.display = "flex";
-  section.style.flexDirection = "column";
-  section.style.gap = "12px";
-  section.style.padding = "16px";
-  root.appendChild(section);
+  function typeLabel(goal) {
+    if (goal.type === "hebdo") {
+      return `Semaine ${goal.weekOfMonth || "?"}`;
+    }
+    if (goal.type === "mensuel") {
+      return "Mensuel";
+    }
+    return goal.type || "Objectif";
+  }
 
-  const header = document.createElement("div");
-  header.className = "goal-header";
-  header.innerHTML = `
-    <div>
-      <h2 class="text-lg font-semibold">Objectifs</h2>
-      <p class="text-sm text-[var(--muted)]">Quatre semaines par mois, saisie rapide incluse.</p>
-    </div>
-    <div class="flex gap-2">
-      <button type="button" class="btn btn-primary" data-new-goal>＋ Nouvel objectif</button>
-    </div>
-  `;
-  section.appendChild(header);
+  async function renderGoals(ctx, root) {
+    lastMount = root;
+    root.innerHTML = "";
 
-  header.querySelector("[data-new-goal]").onclick = () => openGoalForm(ctx);
+    const section = document.createElement("section");
+    section.className = "card";
+    section.style.display = "flex";
+    section.style.flexDirection = "column";
+    section.style.gap = "12px";
+    section.style.padding = "16px";
+    root.appendChild(section);
 
-  const timeline = document.createElement("div");
-  timeline.className = "goal-timeline";
-  section.appendChild(timeline);
-
-  const topSentinel = document.createElement("div");
-  const bottomSentinel = document.createElement("div");
-  topSentinel.style.height = bottomSentinel.style.height = "1px";
-  timeline.appendChild(topSentinel);
-  timeline.appendChild(bottomSentinel);
-
-  const rendered = new Set();
-  const months = [];
-
-  const createGoalRow = (goal) => {
-    const row = document.createElement("div");
-    row.className = "goal-row";
-    const subtitle = typeLabel(goal);
-    row.innerHTML = `
-      <div class="goal-title">
-        <div>${escapeHtml(goal.titre || "Objectif")}</div>
-        <div class="text-xs text-[var(--muted)]">${escapeHtml(subtitle)}</div>
+    const header = document.createElement("div");
+    header.className = "goal-header";
+    header.innerHTML = `
+      <div>
+        <h2 class="text-lg font-semibold">Objectifs</h2>
+        <p class="text-sm text-[var(--muted)]">Quatre semaines par mois, saisie rapide incluse.</p>
       </div>
-      <div class="goal-quick">
-        <select class="select-compact">
-          <option value="">— choisir —</option>
-          <option value="0">Pas de réponse</option>
-          <option value="1">Non</option>
-          <option value="2">Plutôt non</option>
-          <option value="3">Neutre</option>
-          <option value="4">Plutôt oui</option>
-          <option value="5">Oui</option>
-        </select>
+      <div class="flex gap-2">
+        <button type="button" class="btn btn-primary" data-new-goal>＋ Nouvel objectif</button>
       </div>
     `;
-    const select = row.querySelector("select");
-    select.addEventListener("change", async () => {
-      if (select.value === "") return;
-      const todayIso = new Date().toISOString().slice(0, 10);
-      try {
-        await Schema.saveObjectiveEntry(
-          ctx.db,
-          ctx.user.uid,
-          goal.id,
-          todayIso,
-          Number(select.value || 0)
-        );
-        row.style.outline = "2px solid #86efac";
-        setTimeout(() => { row.style.outline = "none"; }, 600);
-      } catch (err) {
-        goalsLogger.error("goals.quickEntry.error", err);
-        row.style.outline = "2px solid #fca5a5";
-        setTimeout(() => { row.style.outline = "none"; }, 800);
-      }
-    });
-    return row;
-  };
+    section.appendChild(header);
 
-  const renderMonth = async (monthKey, where = "end") => {
-    if (rendered.has(monthKey)) return;
-    rendered.add(monthKey);
-    months.push(monthKey);
-    months.sort();
+    header.querySelector("[data-new-goal]").onclick = () => openGoalForm(ctx);
 
-    const box = document.createElement("section");
-    box.className = "goal-month";
-    box.dataset.month = monthKey;
-    const title = document.createElement("h3");
-    title.textContent = monthKey;
-    box.appendChild(title);
+    const timeline = document.createElement("div");
+    timeline.className = "goal-timeline";
+    section.appendChild(timeline);
 
-    const weeks = Schema.weeksOf(monthKey);
-    const containers = new Map();
-    weeks.forEach((week, idx) => {
-      const weekBox = document.createElement("div");
-      weekBox.className = "goal-week";
-      weekBox.dataset.week = String(week);
-      const label = document.createElement("div");
-      label.className = "muted";
-      label.style.marginBottom = "6px";
-      label.textContent = `Semaine ${week}`;
-      const list = document.createElement("div");
-      list.className = "goal-list";
-      weekBox.appendChild(label);
-      weekBox.appendChild(list);
-      containers.set(week, list);
-      box.appendChild(weekBox);
-      if (idx === 0) {
-        weekBox.classList.add("first-week");
-      }
-    });
+    const topSentinel = document.createElement("div");
+    const bottomSentinel = document.createElement("div");
+    topSentinel.style.height = bottomSentinel.style.height = "1px";
+    timeline.appendChild(topSentinel);
+    timeline.appendChild(bottomSentinel);
 
-    let goals = [];
-    try {
-      goals = await Schema.listObjectivesByMonth(ctx.db, ctx.user.uid, monthKey);
-    } catch (err) {
-      goalsLogger.error("goals.month.load", err);
-    }
+    const rendered = new Set();
+    const months = [];
 
-    goals.sort((a, b) => (a.titre || "").localeCompare(b.titre || ""));
-
-    let hasContent = false;
-    const firstWeek = weeks[0];
-
-    weeks.forEach((week) => {
-      const list = containers.get(week);
-      if (!list) return;
-      const items = goals.filter((goal) => {
-        if (goal.type === "hebdo") {
-          return Number(goal.weekOfMonth || 1) === week;
-        }
-        return week === firstWeek;
-      });
-      items.forEach((goal) => {
-        hasContent = true;
-        list.appendChild(createGoalRow(goal));
-      });
-    });
-
-    if (!hasContent) {
-      const empty = document.createElement("div");
-      empty.className = "goal-empty muted";
-      empty.textContent = "Aucun objectif pour ce mois.";
-      box.appendChild(empty);
-    }
-
-    if (where === "start") {
-      const nextSibling = timeline.children[1] || bottomSentinel;
-      timeline.insertBefore(box, nextSibling);
-    } else {
-      timeline.insertBefore(box, bottomSentinel);
-    }
-  };
-
-  const observer = new IntersectionObserver(async (entries) => {
-    for (const entry of entries) {
-      if (!entry.isIntersecting) continue;
-      if (entry.target === topSentinel) {
-        const base = months[0] || Schema.monthKeyFromDate(new Date());
-        await renderMonth(monthShift(base, -1), "start");
-      } else if (entry.target === bottomSentinel) {
-        const base = months[months.length - 1] || Schema.monthKeyFromDate(new Date());
-        await renderMonth(monthShift(base, 1), "end");
-      }
-    }
-  }, { root: null, rootMargin: "300px" });
-
-  const currentMonth = Schema.monthKeyFromDate(new Date());
-  await renderMonth(currentMonth, "end");
-  observer.observe(topSentinel);
-  observer.observe(bottomSentinel);
-}
-
-function openGoalForm(ctx, goal = null) {
-  const monthKey = goal?.monthKey || Schema.monthKeyFromDate(new Date());
-  let weekOfMonth = Number(goal?.weekOfMonth || 1);
-  const typeInitial = goal?.type || "hebdo";
-
-  const wrap = document.createElement("div");
-  wrap.className = "goal-modal";
-  wrap.innerHTML = `
-    <div class="goal-modal-card">
-      <div class="goal-modal-header">
-        <div class="goal-modal-title">${goal ? "Modifier" : "Nouvel"} objectif</div>
-        <button class="btn-ghost" type="button" data-close>✕</button>
-      </div>
-      <form class="goal-form" id="goal-form">
-        <label class="goal-field">
-          <span class="goal-label">Titre</span>
-          <input name="titre" required class="goal-input" value="${escapeHtml(goal?.titre || "")}" placeholder="Nom de l’objectif">
-        </label>
-        <label class="goal-field">
-          <span class="goal-label">Type</span>
-          <select id="obj-type" class="goal-input">
-            <option value="hebdo" ${typeInitial === "hebdo" ? "selected" : ""}>Hebdomadaire</option>
-            <option value="mensuel" ${typeInitial === "mensuel" ? "selected" : ""}>Mensuel</option>
+    const createGoalRow = (goal) => {
+      const row = document.createElement("div");
+      row.className = "goal-row";
+      const subtitle = typeLabel(goal);
+      row.innerHTML = `
+        <div class="goal-title">
+          <div>${escapeHtml(goal.titre || "Objectif")}</div>
+          <div class="text-xs text-[var(--muted)]">${escapeHtml(subtitle)}</div>
+        </div>
+        <div class="goal-quick">
+          <select class="select-compact">
+            <option value="">— choisir —</option>
+            <option value="0">Pas de réponse</option>
+            <option value="1">Non</option>
+            <option value="2">Plutôt non</option>
+            <option value="3">Neutre</option>
+            <option value="4">Plutôt oui</option>
+            <option value="5">Oui</option>
           </select>
-        </label>
-        <div class="goal-field" id="week-picker">
-          <span class="goal-label">Semaine</span>
-          <div class="week-picker">
-            <button type="button" class="btn-ghost" data-w="1">S1</button>
-            <button type="button" class="btn-ghost" data-w="2">S2</button>
-            <button type="button" class="btn-ghost" data-w="3">S3</button>
-            <button type="button" class="btn-ghost" data-w="4">S4</button>
-          </div>
         </div>
-        <label class="goal-field">
-          <span class="goal-label">Description</span>
-          <textarea name="description" rows="3" class="goal-input" placeholder="Notes facultatives">${escapeHtml(goal?.description || "")}</textarea>
-        </label>
-        <div class="goal-actions">
-          <button type="button" class="btn btn-ghost" data-close>Annuler</button>
-          <button type="submit" class="btn btn-primary">Enregistrer</button>
-        </div>
-      </form>
-    </div>
-  `;
-  document.body.appendChild(wrap);
-
-  const close = () => wrap.remove();
-  wrap.addEventListener("click", (event) => {
-    if (event.target === wrap) close();
-  });
-  wrap.querySelectorAll("[data-close]").forEach((btn) => {
-    btn.addEventListener("click", close);
-  });
-
-  const form = wrap.querySelector("#goal-form");
-  const typeSelect = form.querySelector("#obj-type");
-  const weekPicker = form.querySelector("#week-picker");
-  const weekButtons = form.querySelectorAll("#week-picker [data-w]");
-
-  const syncWeekPicker = () => {
-    weekPicker.style.display = typeSelect.value === "hebdo" ? "" : "none";
-  };
-  syncWeekPicker();
-
-  weekButtons.forEach((btn) => {
-    const value = Number(btn.dataset.w || "1");
-    if (value === weekOfMonth) {
-      btn.classList.add("is-active");
-    }
-    btn.addEventListener("click", (event) => {
-      event.preventDefault();
-      weekOfMonth = value;
-      weekButtons.forEach((other) => other.classList.toggle("is-active", other === btn));
-    });
-  });
-
-  typeSelect.addEventListener("change", syncWeekPicker);
-
-  form.addEventListener("submit", async (event) => {
-    event.preventDefault();
-    const titre = form.querySelector("[name=titre]").value.trim();
-    if (!titre) {
-      alert("Le titre est obligatoire.");
-      return;
-    }
-    const description = form.querySelector("[name=description]").value.trim();
-    const type = typeSelect.value;
-
-    const data = {
-      titre,
-      description,
-      type,
-      monthKey,
+      `;
+      const select = row.querySelector("select");
+      select.addEventListener("change", async () => {
+        if (select.value === "") return;
+        const todayIso = new Date().toISOString().slice(0, 10);
+        try {
+          await Schema.saveObjectiveEntry(
+            ctx.db,
+            ctx.user.uid,
+            goal.id,
+            todayIso,
+            Number(select.value || 0)
+          );
+          row.style.outline = "2px solid #86efac";
+          setTimeout(() => { row.style.outline = "none"; }, 600);
+        } catch (err) {
+          goalsLogger.error("goals.quickEntry.error", err);
+          row.style.outline = "2px solid #fca5a5";
+          setTimeout(() => { row.style.outline = "none"; }, 800);
+        }
+      });
+      return row;
     };
-    if (type === "hebdo") {
-      data.weekOfMonth = weekOfMonth;
-    }
 
-    try {
-      await Schema.upsertObjective(ctx.db, ctx.user.uid, data, goal?.id || null);
-      close();
-      if (lastMount) {
-        renderGoals(ctx, lastMount);
+    const renderMonth = async (monthKey, where = "end") => {
+      if (rendered.has(monthKey)) return;
+      rendered.add(monthKey);
+      months.push(monthKey);
+      months.sort();
+
+      const box = document.createElement("section");
+      box.className = "goal-month";
+      box.dataset.month = monthKey;
+      const title = document.createElement("h3");
+      title.textContent = monthKey;
+      box.appendChild(title);
+
+      const weeks = Schema.weeksOf(monthKey);
+      const containers = new Map();
+      weeks.forEach((week, idx) => {
+        const weekBox = document.createElement("div");
+        weekBox.className = "goal-week";
+        weekBox.dataset.week = String(week);
+        const label = document.createElement("div");
+        label.className = "muted";
+        label.style.marginBottom = "6px";
+        label.textContent = `Semaine ${week}`;
+        const list = document.createElement("div");
+        list.className = "goal-list";
+        weekBox.appendChild(label);
+        weekBox.appendChild(list);
+        containers.set(week, list);
+        box.appendChild(weekBox);
+        if (idx === 0) {
+          weekBox.classList.add("first-week");
+        }
+      });
+
+      let goals = [];
+      try {
+        goals = await Schema.listObjectivesByMonth(ctx.db, ctx.user.uid, monthKey);
+      } catch (err) {
+        goalsLogger.error("goals.month.load", err);
       }
-    } catch (err) {
-      goalsLogger.error("goals.save.error", err);
-      alert("Impossible d'enregistrer l’objectif.");
-    }
-  });
-}
 
-Goals.renderGoals = renderGoals;
-Goals.openGoalForm = openGoalForm;
+      goals.sort((a, b) => (a.titre || "").localeCompare(b.titre || ""));
+
+      let hasContent = false;
+      const firstWeek = weeks[0];
+
+      weeks.forEach((week) => {
+        const list = containers.get(week);
+        if (!list) return;
+        const items = goals.filter((goal) => {
+          if (goal.type === "hebdo") {
+            return Number(goal.weekOfMonth || 1) === week;
+          }
+          return week === firstWeek;
+        });
+        items.forEach((goal) => {
+          hasContent = true;
+          list.appendChild(createGoalRow(goal));
+        });
+      });
+
+      if (!hasContent) {
+        const empty = document.createElement("div");
+        empty.className = "goal-empty muted";
+        empty.textContent = "Aucun objectif pour ce mois.";
+        box.appendChild(empty);
+      }
+
+      if (where === "start") {
+        const nextSibling = timeline.children[1] || bottomSentinel;
+        timeline.insertBefore(box, nextSibling);
+      } else {
+        timeline.insertBefore(box, bottomSentinel);
+      }
+    };
+
+    const observer = new IntersectionObserver(async (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        if (entry.target === topSentinel) {
+          const base = months[0] || Schema.monthKeyFromDate(new Date());
+          await renderMonth(monthShift(base, -1), "start");
+        } else if (entry.target === bottomSentinel) {
+          const base = months[months.length - 1] || Schema.monthKeyFromDate(new Date());
+          await renderMonth(monthShift(base, 1), "end");
+        }
+      }
+    }, { root: null, rootMargin: "300px" });
+
+    const currentMonth = Schema.monthKeyFromDate(new Date());
+    await renderMonth(currentMonth, "end");
+    observer.observe(topSentinel);
+    observer.observe(bottomSentinel);
+  }
+
+  function openGoalForm(ctx, goal = null) {
+    const monthKey = goal?.monthKey || Schema.monthKeyFromDate(new Date());
+    let weekOfMonth = Number(goal?.weekOfMonth || 1);
+    const typeInitial = goal?.type || "hebdo";
+
+    const wrap = document.createElement("div");
+    wrap.className = "goal-modal";
+    wrap.innerHTML = `
+      <div class="goal-modal-card">
+        <div class="goal-modal-header">
+          <div class="goal-modal-title">${goal ? "Modifier" : "Nouvel"} objectif</div>
+          <button class="btn-ghost" type="button" data-close>✕</button>
+        </div>
+        <form class="goal-form" id="goal-form">
+          <label class="goal-field">
+            <span class="goal-label">Titre</span>
+            <input name="titre" required class="goal-input" value="${escapeHtml(goal?.titre || "")}" placeholder="Nom de l’objectif">
+          </label>
+          <label class="goal-field">
+            <span class="goal-label">Type</span>
+            <select id="obj-type" class="goal-input">
+              <option value="hebdo" ${typeInitial === "hebdo" ? "selected" : ""}>Hebdomadaire</option>
+              <option value="mensuel" ${typeInitial === "mensuel" ? "selected" : ""}>Mensuel</option>
+            </select>
+          </label>
+          <div class="goal-field" id="week-picker">
+            <span class="goal-label">Semaine</span>
+            <div class="week-picker">
+              <button type="button" class="btn-ghost" data-w="1">S1</button>
+              <button type="button" class="btn-ghost" data-w="2">S2</button>
+              <button type="button" class="btn-ghost" data-w="3">S3</button>
+              <button type="button" class="btn-ghost" data-w="4">S4</button>
+            </div>
+          </div>
+          <label class="goal-field">
+            <span class="goal-label">Description</span>
+            <textarea name="description" rows="3" class="goal-input" placeholder="Notes facultatives">${escapeHtml(goal?.description || "")}</textarea>
+          </label>
+          <div class="goal-actions">
+            <button type="button" class="btn btn-ghost" data-close>Annuler</button>
+            <button type="submit" class="btn btn-primary">Enregistrer</button>
+          </div>
+        </form>
+      </div>
+    `;
+    document.body.appendChild(wrap);
+
+    const close = () => wrap.remove();
+    wrap.addEventListener("click", (event) => {
+      if (event.target === wrap) close();
+    });
+    wrap.querySelectorAll("[data-close]").forEach((btn) => {
+      btn.addEventListener("click", close);
+    });
+
+    const form = wrap.querySelector("#goal-form");
+    const typeSelect = form.querySelector("#obj-type");
+    const weekPicker = form.querySelector("#week-picker");
+    const weekButtons = form.querySelectorAll("#week-picker [data-w]");
+
+    const syncWeekPicker = () => {
+      weekPicker.style.display = typeSelect.value === "hebdo" ? "" : "none";
+    };
+    syncWeekPicker();
+
+    weekButtons.forEach((btn) => {
+      const value = Number(btn.dataset.w || "1");
+      if (value === weekOfMonth) {
+        btn.classList.add("is-active");
+      }
+      btn.addEventListener("click", (event) => {
+        event.preventDefault();
+        weekOfMonth = value;
+        weekButtons.forEach((other) => other.classList.toggle("is-active", other === btn));
+      });
+    });
+
+    typeSelect.addEventListener("change", syncWeekPicker);
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const titre = form.querySelector("[name=titre]").value.trim();
+      if (!titre) {
+        alert("Le titre est obligatoire.");
+        return;
+      }
+      const description = form.querySelector("[name=description]").value.trim();
+      const type = typeSelect.value;
+
+      const data = {
+        titre,
+        description,
+        type,
+        monthKey,
+      };
+      if (type === "hebdo") {
+        data.weekOfMonth = weekOfMonth;
+      }
+
+      try {
+        await Schema.upsertObjective(ctx.db, ctx.user.uid, data, goal?.id || null);
+        close();
+        if (lastMount) {
+          renderGoals(ctx, lastMount);
+        }
+      } catch (err) {
+        goalsLogger.error("goals.save.error", err);
+        alert("Impossible d'enregistrer l’objectif.");
+      }
+    });
+  }
+
+  GoalsNS.renderGoals = renderGoals;
+  GoalsNS.openGoalForm = openGoalForm;
+})();


### PR DESCRIPTION
## Summary
- wrap the bootstrap/router code in `app.js` inside an IIFE with a reinitialization guard so the script no longer redeclares globals when injected twice
- isolate the goals timeline helpers in `goals.js` inside the same pattern and expose them through a single namespace

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d29a18e38483339d01a8c63b90c179