### PR TITLE
Fix Firestore snapshot exists compatibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,9 @@
   }
   window.__APP_ROUTER_INITIALIZED__ = true;
   const appFirestore = Schema.firestore || window.firestoreAPI || {};
+  const snapshotExists =
+    Schema.snapshotExists ||
+    ((snap) => (typeof snap?.exists === "function" ? snap.exists() : !!snap?.exists));
 
   const firebaseCompatApp = window.firebase || {};
 
@@ -364,7 +367,7 @@
     appLog("profile:ensure:start", { uid });
     const ref = appFirestore.doc(db, "u", uid);
     const snap = await appFirestore.getDoc(ref);
-    if (snap.exists()) {
+    if (snapshotExists(snap)) {
       const data = snap.data();
       appLog("profile:ensure:existing", { uid });
       return data;


### PR DESCRIPTION
## Summary
- add a shared helper that tolerates both boolean and function forms of Firestore snapshot existence checks
- update schema helpers and profile bootstrap to rely on the compatibility helper and avoid runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d29df0f2ec833387a50315ef34d1bd