### PR TITLE
Enhance daily persistence and goals UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,108 @@
       box-shadow: inset 0 0 0 2px var(--accent-200);
     }
 
+    /* Journalier — catégories */
+    .daily-category {
+      position: relative;
+      background:#fff;
+      border-radius:1.2rem;
+      border:1px solid rgba(148, 163, 184, .25);
+      padding:1.1rem 1.25rem 1.25rem;
+      box-shadow:0 10px 24px rgba(15,23,42,.08);
+      overflow:hidden;
+    }
+    .daily-category::before {
+      content:"";
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      border-left:6px solid var(--accent-400);
+      pointer-events:none;
+      opacity:.25;
+    }
+    .daily-category__header {
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:.75rem;
+      margin-bottom:.9rem;
+      position:relative;
+      z-index:1;
+    }
+    .daily-category__name {
+      font-weight:700;
+      font-size:1.05rem;
+      text-transform:capitalize;
+    }
+    .daily-category__count {
+      font-size:.75rem;
+      color:var(--muted);
+      background:var(--accent-50);
+      border:1px solid var(--accent-200);
+      border-radius:999px;
+      padding:.2rem .6rem;
+    }
+    .daily-category__items {
+      display:grid;
+      gap:.8rem;
+      position:relative;
+      z-index:1;
+    }
+    .daily-category__low {
+      border-radius:1rem;
+      border:1px dashed rgba(148,163,184,.35);
+      background:rgba(241,245,249,.75);
+      padding:.75rem;
+    }
+    .daily-category__low[open] {
+      background:#fff;
+    }
+    .daily-category__low-summary {
+      list-style:none;
+      cursor:pointer;
+      font-size:.8rem;
+      font-weight:600;
+      color:var(--muted);
+      display:flex;
+      align-items:center;
+      gap:.35rem;
+    }
+    .daily-category__low-summary::-webkit-details-marker {
+      display:none;
+    }
+    .daily-category__items--nested {
+      margin-top:.65rem;
+      display:grid;
+      gap:.75rem;
+    }
+    .daily-consigne {
+      background:#fff;
+      border-radius:1rem;
+      border:1px solid rgba(148,163,184,.25);
+      box-shadow:0 8px 20px rgba(15,23,42,.06);
+      padding:.9rem 1rem;
+      display:grid;
+      gap:.75rem;
+    }
+    .daily-consigne__top {
+      display:flex;
+      flex-wrap:wrap;
+      align-items:flex-start;
+      justify-content:space-between;
+      gap:.75rem;
+    }
+    .daily-consigne__title {
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      gap:.5rem;
+    }
+    .daily-consigne__field {
+      display:block;
+    }
+
     /* Pastilles de priorité */
-    .prio-chip { 
+    .prio-chip {
       display:inline-flex; align-items:center; gap:.4rem;
       padding:.15rem .5rem; border-radius:999px;
       font-size:.75rem; border:1px solid transparent;
@@ -97,13 +197,24 @@
     /* Objectifs */
     .goal-header{ display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap; margin-bottom:12px; }
     .goal-timeline{ display:grid; gap:12px; padding:8px 0; }
-    .goal-month{ background:#fff; border-radius:16px; box-shadow:0 2px 12px rgba(0,0,0,.08); padding:12px; }
-    .goal-month h3{ margin:0 0 8px; font-weight:700; font-size:1.05rem; }
-    .goal-week{ padding:8px 0; border-top:1px dashed #e5e7eb; }
+    .goal-month{ background:#fff; border-radius:16px; box-shadow:0 10px 28px rgba(79,70,229,.08); padding:16px; border:1px solid rgba(148,163,184,.2); }
+    .goal-month--current{ border-color:var(--accent-400); box-shadow:0 12px 32px rgba(99,102,241,.14); }
+    .goal-month__header{ display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:1rem; }
+    .goal-month__title{ margin:0; font-weight:700; font-size:1.15rem; text-transform:capitalize; }
+    .goal-month__add{ padding:.35rem .9rem; border-radius:999px; font-size:.85rem; }
+    .goal-monthly{ border:1px dashed rgba(148,163,184,.35); background:rgba(236,233,255,.6); border-radius:14px; padding:.85rem 1rem; margin-bottom:1rem; }
+    .goal-monthly__title{ font-size:.85rem; font-weight:600; color:#5b21b6; text-transform:uppercase; letter-spacing:.03em; }
+    .goal-week{ padding:10px 0; border-top:1px dashed #e5e7eb; }
     .goal-week:first-of-type{ border-top:none; padding-top:0; }
-    .goal-week .muted{ font-size:.8rem; }
-    .goal-row{ display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 8px; border-radius:10px; transition:background .15s ease, outline .15s ease; }
-    .goal-row:hover{ background:#f8fafc; }
+    .goal-week__header{ display:flex; align-items:center; justify-content:space-between; gap:.5rem; margin-bottom:.45rem; }
+    .goal-week__label{ font-size:.82rem; }
+    .goal-week__add{ padding:.25rem .75rem; font-size:.78rem; border-radius:999px; }
+    .goal-row{ display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 10px; border-radius:12px; transition:background .15s ease, box-shadow .15s ease; border-left:4px solid transparent; }
+    .goal-row:hover{ box-shadow:0 6px 14px rgba(15,23,42,.08); }
+    .goal-row--positive{ background:#ecfdf5; border-left-color:#22c55e; }
+    .goal-row--neutral{ background:#fefce8; border-left-color:#fbbf24; }
+    .goal-row--negative{ background:#fef2f2; border-left-color:#f87171; }
+    .goal-row--none{ background:#f8fafc; border-left-color:#94a3b8; }
     .goal-title{ font-weight:600; flex:1; }
     .goal-quick{ min-width:140px; }
     .goal-empty{ padding:1rem; border-radius:.75rem; background:var(--accent-50); }
@@ -111,6 +222,7 @@
     .select-compact:focus{ outline:none; border-color:var(--accent-400); box-shadow:0 0 0 3px var(--accent-50); }
     .week-picker{ display:flex; gap:.5rem; }
     .week-picker button.is-active{ background:var(--accent-600); color:#fff; border-color:var(--accent-600); }
+    .goal-month-pill{ display:inline-flex; align-items:center; gap:.4rem; padding:.35rem .75rem; border-radius:999px; background:var(--accent-50); border:1px solid var(--accent-200); font-size:.85rem; font-weight:600; color:#4338ca; }
 
     .history-scroll{ overflow-x:auto; -webkit-overflow-scrolling:touch; }
     .history-table{ min-width:720px; }


### PR DESCRIPTION
## Summary
- persist daily journal answers per date and pre-fill inputs when returning to a day
- restyle daily categories for clearer visual separation and add goal month/week UI improvements
- localize month headers, show weekly date ranges, color weekly responses, and add contextual creation buttons

## Testing
- npm test *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a208278c8333a2302944ea6f0ed2