### PR TITLE
Ensure objective answers persist after reload

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -669,12 +669,12 @@ async function linkConsigneToObjective(db, uid, consigneId, objectifId) {
 }
 
 async function saveObjectiveEntry(db, uid, objectifId, dateIso, value) {
-  const ref = doc(db, "u", uid, "objectiveEntries", objectifId, dateIso);
+  const ref = doc(db, "u", uid, "objectiveEntries", objectifId, "entries", dateIso);
   await setDoc(ref, { v: value, at: serverTimestamp() }, { merge: true });
 }
 
 async function loadObjectiveEntriesRange(db, uid, objectifId, _fromIso, _toIso) {
-  const colRef = collection(db, "u", uid, "objectiveEntries", objectifId);
+  const colRef = collection(db, "u", uid, "objectiveEntries", objectifId, "entries");
   const snap = await getDocs(colRef);
   return snap.docs.map((d) => ({ date: d.id, v: d.data().v }));
 }


### PR DESCRIPTION
## Summary
- store objective answers in a dedicated `entries` subcollection under each objective
- load answers from the same subcollection when hydrating the monthly view

## Testing
- node tests/weekDateRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2bc2d23008333958549e937c37a93