### PR TITLE
Limit objective weeks to four per month

### DIFF
--- a/tests/weekDateRange.test.js
+++ b/tests/weekDateRange.test.js
@@ -32,22 +32,22 @@ function assertEqual(actual, expected, message) {
 
 function runTests() {
   const aprilWeeks = weeksOf("2023-04");
-  assertEqual(JSON.stringify(aprilWeeks), JSON.stringify([1, 2, 3, 4, 5]), "Avril 2023 devrait compter 5 semaines");
+  assertEqual(JSON.stringify(aprilWeeks), JSON.stringify([1, 2, 3, 4]), "Avril 2023 devrait compter 4 semaines");
 
   const augustRange = weekDateRange("2020-08", 1);
   assert(augustRange, "La première semaine d’août 2020 doit être définie");
   assertEqual(
     augustRange.label,
-    "Semaine du 27 juillet au 02 août",
+    "Semaine du 01 au 09 août",
     "Libellé de la première semaine d’août 2020 incorrect",
   );
 
-  const septemberRange = weekDateRange("2023-09", 5);
-  assert(septemberRange, "La cinquième semaine de septembre 2023 doit être définie");
+  const octoberRange = weekDateRange("2023-10", 4);
+  assert(octoberRange, "La quatrième semaine d’octobre 2023 doit être définie");
   assertEqual(
-    septemberRange.label,
-    "Semaine du 25 au 30 septembre",
-    "Libellé de la dernière semaine de septembre 2023 incorrect",
+    octoberRange.label,
+    "Semaine du 23 au 31 octobre",
+    "Libellé de la dernière semaine d’octobre 2023 incorrect",
   );
 
   assertEqual(
@@ -56,9 +56,9 @@ function runTests() {
     "Le 2 août 2020 devrait appartenir à la première semaine",
   );
   assertEqual(
-    weekOfMonthFromDate(new Date("2020-08-03")),
+    weekOfMonthFromDate(new Date("2020-08-10")),
     2,
-    "Le 3 août 2020 devrait appartenir à la deuxième semaine",
+    "Le 10 août 2020 devrait appartenir à la deuxième semaine",
   );
 }
 


### PR DESCRIPTION
## Summary
- merge partial leading and trailing weeks so each month only exposes four week segments
- base week range and week-of-month helpers on the merged segments for consistent labelling
- update the week range unit test expectations for the new four-week model

## Testing
- node tests/weekDateRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2bf07a144833389af78766401c45a