### PR TITLE
Fix admin rename persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -669,10 +669,14 @@
               return;
             }
             try {
-              await appFirestore.updateDoc(appFirestore.doc(db, "u", uid), {
-                name: trimmed,
-                displayName: trimmed,
-              });
+              await appFirestore.setDoc(
+                appFirestore.doc(db, "u", uid),
+                {
+                  name: trimmed,
+                  displayName: trimmed,
+                },
+                { merge: true }
+              );
               await loadUsers(db);
             } catch (error) {
               console.error("admin:users:rename:error", error);


### PR DESCRIPTION
## Summary
- ensure the admin rename action writes profile updates with a merge so the new name persists

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c6c813fc8333b3748c44283f9c90