### PR TITLE
Improve admin rename logging and diagnostics

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -117,6 +117,7 @@ let boundDb = null;
 
 function bindDb(db) {
   boundDb = db;
+  D.info("bindDb", { hasDb: !!db });
 }
 Schema.bindDb = Schema.bindDb || bindDb;
 
@@ -249,17 +250,22 @@ function hydrateConsigne(doc) {
 
 // --- Catégories & Users ---
 async function getUserName(uid) {
+  D.info("getUserName:start", { uid });
   if (!uid) return "Utilisateur";
   if (!boundDb) {
     console.warn("getUserName error:", new Error("Firestore not initialized"));
+    D.warn("getUserName:missingDb", { uid });
     return "Utilisateur";
   }
   try {
     const snap = await getDoc(doc(boundDb, "u", uid));
     const d = snapshotExists(snap) ? (snap.data() || {}) : {};
-    return d.name || d.displayName || d.slug || "Utilisateur";
+    const resolved = d.name || d.displayName || d.slug || "Utilisateur";
+    D.info("getUserName:result", { uid, resolved });
+    return resolved;
   } catch (e) {
     console.warn("getUserName error:", e);
+    D.warn("getUserName:error", { uid, message: e?.message || String(e) });
     return "Utilisateur";
   }
 }


### PR DESCRIPTION
## Summary
- enable verbose application logging by default and surface app logs in the console
- add detailed admin user management logs with post-write verification for rename operations
- log Firestore binding and user name lookups to aid debugging across the app

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2c9705f1c8333b62d8046a95ae477