### PR TITLE
Fix snapshot existence detection for compat snapshots

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -93,8 +93,20 @@ const snapshotExists =
   Schema.snapshotExists ||
   ((snap) => {
     if (!snap) return false;
-    if (typeof snap.exists === "function") return snap.exists();
-    if (Object.prototype.hasOwnProperty.call(snap, "exists")) return !!snap.exists;
+    const { exists } = snap;
+    if (typeof exists === "function") {
+      try {
+        return !!exists.call(snap);
+      } catch (error) {
+        console.warn("snapshotExists:call:error", error);
+      }
+    }
+    if (exists !== undefined) {
+      return !!exists;
+    }
+    if ("exists" in snap) {
+      return !!snap.exists;
+    }
     return false;
   });
 Schema.snapshotExists = Schema.snapshotExists || snapshotExists;


### PR DESCRIPTION
## Summary
- ensure `Schema.snapshotExists` detects compat snapshot instances that expose `exists` via prototype
- prevent admin profile initialisation from overwriting renamed display names

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ce3e88a083339ab7efdac4f3b626