### PR TITLE
Refine practice dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,6 +329,82 @@
     .goal-actions [data-delete]{ margin-right:auto; }
     .goal-list{ margin-top:.5rem; padding-left:1.25rem; display:grid; gap:.35rem; list-style:disc; }
 
+    .practice-dashboard__card{ width:min(1040px,96vw); max-height:92vh; display:flex; flex-direction:column; gap:1.5rem; padding:1.5rem 1.75rem; overflow:hidden; }
+    .practice-dashboard__header{ display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; }
+    .practice-dashboard__title{ font-size:1.35rem; font-weight:700; color:#0f172a; }
+    .practice-dashboard__subtitle{ color:#64748B; font-size:.95rem; }
+    .practice-dashboard__close{ margin-left:auto; }
+    .practice-dashboard__body{ overflow-y:auto; padding-right:.5rem; margin-right:-.25rem; display:flex; flex-direction:column; gap:1.5rem; }
+    .practice-dashboard__summary{ display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+    .practice-dashboard__summary-card{ border-radius:1rem; padding:1rem 1.15rem; border:1px solid var(--summary-border,#E2E8F0); background:var(--summary-bg,#F8FAFC); display:flex; flex-direction:column; gap:.75rem; min-width:220px; scroll-snap-align:start; }
+    .practice-dashboard__summary-header{ display:flex; align-items:center; justify-content:space-between; gap:.75rem; }
+    .practice-dashboard__summary-title{ font-weight:600; font-size:1rem; color:#0f172a; }
+    .practice-dashboard__summary-metric{ font-size:1.35rem; font-weight:700; color:var(--summary-accent,#0f172a); }
+    .practice-dashboard__summary-meta{ display:grid; gap:.4rem; }
+    .practice-dashboard__summary-meta div{ display:flex; flex-direction:column; gap:.2rem; font-size:.85rem; color:#475569; }
+    .practice-dashboard__summary-meta dt{ font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:#94A3B8; }
+    .practice-dashboard__badge{ display:inline-flex; align-items:center; gap:.35rem; padding:.2rem .6rem; border-radius:999px; font-size:.75rem; font-weight:600; }
+    .practice-dashboard__badge--high{ background:#FEE2E2; color:#B91C1C; }
+    .practice-dashboard__badge--medium{ background:#FEF3C7; color:#92400E; }
+    .practice-dashboard__badge--low{ background:#DBEAFE; color:#1D4ED8; }
+    .practice-dashboard__view-switch{ display:flex; gap:.5rem; background:#F1F5F9; border-radius:999px; padding:.3rem; width:max-content; }
+    .practice-dashboard__view-btn{ border:none; background:transparent; padding:.45rem 1.1rem; border-radius:999px; font-weight:600; font-size:.85rem; color:#64748B; cursor:pointer; transition:background .15s ease,color .15s ease, box-shadow .15s ease; }
+    .practice-dashboard__view-btn.is-active{ background:#fff; color:#0f172a; box-shadow:0 2px 6px rgba(15,23,42,.12); }
+    .practice-dashboard__view{ display:none; flex-direction:column; gap:1.25rem; }
+    .practice-dashboard__view.is-active{ display:flex; }
+    .practice-dashboard__controls{ display:flex; flex-wrap:wrap; gap:1rem; align-items:flex-end; }
+    .practice-dashboard__control{ display:flex; flex-direction:column; gap:.35rem; min-width:220px; flex:1 1 220px; }
+    .practice-dashboard__control-label{ font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; color:#94A3B8; font-weight:600; }
+    .practice-dashboard__table-wrapper{ margin-top:.75rem; border:1px solid #E2E8F0; border-radius:1rem; overflow:auto; background:#fff; box-shadow:0 18px 32px rgba(15,23,42,.08); }
+    .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:8px; }
+    .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:#CBD5F5; border-radius:999px; }
+    .practice-dashboard__table{ width:100%; border-collapse:separate; border-spacing:0; min-width:720px; }
+    .practice-dashboard__table thead th{ background:#F8FAFC; padding:.75rem 1rem; text-align:left; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:#94A3B8; border-bottom:1px solid #E2E8F0; }
+    .practice-dashboard__table tbody td{ padding:.9rem 1rem; vertical-align:top; border-bottom:1px solid #F1F5F9; font-size:.9rem; color:#334155; }
+    .practice-dashboard__table tbody tr:last-child td{ border-bottom:none; }
+    .practice-dashboard__table tbody tr{ transition:background .15s ease; box-shadow:inset 0 0 0 0 transparent; }
+    .practice-dashboard__table tbody tr:hover{ background:#F8FAFC; }
+    .practice-dashboard__table tbody tr[data-priority]{ box-shadow:inset 3px 0 0 var(--row-accent,transparent); }
+    .practice-dashboard__consigne{ display:flex; flex-direction:column; gap:.4rem; }
+    .practice-dashboard__consigne-name{ font-weight:600; font-size:1rem; color:#0f172a; }
+    .practice-dashboard__consigne-meta{ display:flex; flex-wrap:wrap; gap:.5rem; align-items:center; }
+    .practice-dashboard__tag{ display:inline-flex; align-items:center; padding:.2rem .55rem; border-radius:.75rem; background:#E2E8F0; color:#475569; font-size:.7rem; font-weight:500; text-transform:uppercase; letter-spacing:.08em; }
+    .practice-dashboard__date{ display:flex; flex-direction:column; gap:.25rem; font-size:.9rem; }
+    .practice-dashboard__date-sub{ font-size:.75rem; color:#94A3B8; text-transform:uppercase; letter-spacing:.08em; }
+    .practice-dashboard__status{ display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
+    .status-chip{ display:inline-flex; align-items:center; gap:.35rem; padding:.2rem .65rem; border-radius:999px; font-size:.75rem; font-weight:600; }
+    .status-chip--ok{ background:#DCFCE7; color:#166534; }
+    .status-chip--mid{ background:#FEF3C7; color:#92400E; }
+    .status-chip--ko{ background:#FEE2E2; color:#B91C1C; }
+    .status-chip--na{ background:#E2E8F0; color:#475569; }
+    .practice-dashboard__history{ border:1px solid #E2E8F0; background:#fff; color:#0f172a; border-radius:.5rem; padding:.25rem .6rem; font-size:.75rem; font-weight:500; transition:background .15s ease, color .15s ease, border-color .15s ease; }
+    .practice-dashboard__history:hover{ border-color:var(--accent-200); background:var(--accent-50); }
+    .practice-dashboard__comment{ font-size:.85rem; color:#475569; line-height:1.45; max-width:22rem; display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
+    .practice-dashboard__score{ display:flex; flex-direction:column; gap:.4rem; font-size:.9rem; color:#0f172a; }
+    .practice-dashboard__progress{ position:relative; height:.4rem; border-radius:999px; background:#E2E8F0; overflow:hidden; }
+    .practice-dashboard__progress>div{ position:absolute; inset:0; background:var(--progress-color,var(--accent-600)); border-radius:inherit; transition:width .2s ease; }
+    .practice-dashboard__chart-card{ border:1px solid #E2E8F0; border-radius:1rem; background:#fff; padding:1rem 1.25rem; min-height:280px; box-shadow:0 18px 32px rgba(15,23,42,.08); position:relative; }
+    .practice-dashboard__chart-card canvas{ width:100%; height:100%; }
+    .practice-dashboard__chart-caption{ font-size:.85rem; color:#64748B; }
+    .practice-dashboard__empty{ padding:1.25rem; border-radius:1rem; border:1px dashed #CBD5F5; background:#F8FAFC; font-size:.9rem; color:#64748B; text-align:center; }
+    .practice-dashboard__empty-row{ padding:2.5rem 1rem; text-align:center; font-size:.9rem; color:#94A3B8; }
+
+    @media (max-width: 768px){
+      .practice-dashboard__table{ min-width:640px; }
+      .practice-dashboard__body{ padding-right:0; margin-right:0; }
+    }
+    @media (max-width: 640px){
+      .practice-dashboard__card{ padding:1.25rem; }
+      .practice-dashboard__summary{ display:flex; overflow-x:auto; gap:.75rem; padding-bottom:.5rem; margin-right:-1rem; padding-right:1rem; scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch; }
+      .practice-dashboard__summary::-webkit-scrollbar{ display:none; }
+      .practice-dashboard__summary-card{ min-width:240px; }
+      .practice-dashboard__controls{ flex-direction:column; align-items:stretch; }
+      .practice-dashboard__control{ width:100%; }
+      .practice-dashboard__table-wrapper{ overflow-x:auto; }
+      .practice-dashboard__view-switch{ width:100%; justify-content:space-between; }
+      .practice-dashboard__view-btn{ flex:1; text-align:center; }
+    }
+
   </style>
 </head>
 <body class="min-h-screen">


### PR DESCRIPTION
## Summary
- rebuild the practice category dashboard modal with summary cards, filters, and richer chart interactions for habit tracking
- add styling for the new dashboard views including badges, table layout, and responsive tweaks

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d2da96f7188333a58b93c8242165cd