### PR TITLE
Fix duplicate iterationLabels declaration

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -664,8 +664,6 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
       stat.chartDatasetIndex = null;
     });
 
-    const iterationLabels = iterationMeta.map((meta) => meta.label);
-
     if (headRow) {
       headRow.innerHTML = [
         '<th scope="col" class="practice-dashboard__matrix-head-consigne">Consigne</th>',


### PR DESCRIPTION
## Summary
- remove the duplicate `iterationLabels` declaration in the practice dashboard modal setup
- rely on the earlier definition so the script no longer throws a SyntaxError when loading

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2f63fe0a88333a806f6dadd6545f7