### PR TITLE
Fix practice iteration key precision

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -303,7 +303,7 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
       }
       if (createdAt) {
         const approx = new Date(createdAt.getTime());
-        approx.setSeconds(0, 0);
+        approx.setMilliseconds(0);
         return `ts-${approx.toISOString()}`;
       }
       const fallback = `resp-${seenFallback.value}`;


### PR DESCRIPTION
## Summary
- preserve seconds when building fallback iteration keys so closely timed entries create distinct columns

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2fc909f4883338ad697dabce12dab