### PR TITLE
Fix practice dashboard iteration display issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,10 +343,11 @@
     .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:8px; }
     .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:#CBD5F5; border-radius:999px; }
     .practice-dashboard__matrix{ width:100%; border-collapse:separate; border-spacing:0; min-width:720px; }
-    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:#F8FAFC; padding:.6rem .75rem; text-align:center; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:#94A3B8; border-bottom:1px solid #E2E8F0; }
+    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:#F8FAFC; padding:.6rem .75rem; text-align:center; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:#94A3B8; border-bottom:1px solid #E2E8F0; z-index:5; }
+    .practice-dashboard__matrix thead th:first-child{ left:0; z-index:6; }
     .practice-dashboard__matrix thead th span{ display:block; white-space:nowrap; }
     .practice-dashboard__matrix-head-consigne{ text-align:left; min-width:220px; }
-    .practice-dashboard__matrix-consigne{ position:sticky; left:0; background:#fff; padding:.75rem .9rem; border-right:1px solid #E2E8F0; box-shadow:1px 0 0 rgba(226,232,240,.6); }
+    .practice-dashboard__matrix-consigne{ position:sticky; left:0; background:#fff; padding:.75rem .9rem; border-right:1px solid #E2E8F0; box-shadow:1px 0 0 rgba(226,232,240,.6); z-index:4; }
     .practice-dashboard__row-head{ display:flex; align-items:center; gap:.75rem; }
     .practice-dashboard__row-indicator{ width:.45rem; height:2.5rem; border-radius:999px; background:var(--row-accent,#CBD5F5); flex-shrink:0; }
     .practice-dashboard__row-info{ display:flex; flex-direction:column; gap:.35rem; }

--- a/modes.js
+++ b/modes.js
@@ -519,20 +519,31 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
             dateObj = toDate(key);
           }
         }
-        const label = `Itération ${sessionNumber != null ? sessionNumber : idx + 1}`;
+        const displayIndex = idx + 1;
+        const label = `Itération ${displayIndex}`;
         let fullLabel = "";
         if (dateObj) {
           fullLabel = fullDateTimeFormatter.format(dateObj);
+        } else if (sessionNumber != null && sessionNumber !== displayIndex) {
+          fullLabel = `Session ${sessionNumber}`;
         } else if (sessionNumber != null) {
           fullLabel = label;
         } else {
           fullLabel = String(key);
         }
-        const headerTitle = fullLabel && fullLabel !== label ? `${label} — ${fullLabel}` : label;
+        const headerParts = [label];
+        if (Number.isFinite(sessionNumber) && sessionNumber !== displayIndex) {
+          headerParts.push(`Session ${sessionNumber}`);
+        }
+        if (fullLabel && fullLabel !== label) {
+          headerParts.push(fullLabel);
+        }
+        const headerTitle = headerParts.join(" — ");
         return {
           key,
           iso: key,
           index: idx,
+          displayIndex,
           label,
           fullLabel,
           headerTitle,
@@ -769,6 +780,11 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
       const parts = [];
       const iterationLabel = iterationInfo?.label;
       if (iterationLabel) parts.push(iterationLabel);
+      const actualNumber = iterationInfo?.sessionNumber;
+      const displayIndex = iterationInfo?.displayIndex;
+      if (Number.isFinite(actualNumber) && actualNumber !== displayIndex) {
+        parts.push(`Session ${actualNumber}`);
+      }
       const iso = iterationInfo?.iso || dateIso;
       const dateObj = iterationInfo?.dateObj || toDate(iso);
       const fullLabel = iterationInfo?.fullLabel || (dateObj ? fullDateTimeFormatter.format(dateObj) : iso);
@@ -1250,6 +1266,9 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
                   const info = iterationMeta[index];
                   if (info) {
                     const parts = [info.label];
+                    if (Number.isFinite(info.sessionNumber) && info.sessionNumber !== info.displayIndex) {
+                      parts.push(`Session ${info.sessionNumber}`);
+                    }
                     if (info.fullLabel && info.fullLabel !== info.label) {
                       parts.push(info.fullLabel);
                     }


### PR DESCRIPTION
## Summary
- ensure practice dashboard iterations are numbered sequentially regardless of stored session numbers
- surface the original session number in tooltips when it differs and enrich chart tooltips
- adjust sticky table headers to avoid overlap while scrolling horizontally

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3000da4f88333af01b50ea6ab608c