### PR TITLE
Fix admin hash workflow syntax

### DIFF
--- a/.github/workflows/generate-admin-hash.yml
+++ b/.github/workflows/generate-admin-hash.yml
@@ -27,14 +27,32 @@ jobs:
         run: |
           set -euo pipefail
           HASH=$(printf "%s" "${ADMIN_PASSWORD}" | sha256sum | cut -d' ' -f1)
-          cat <<EOT > admin-hash.js
-// Ce fichier est généré automatiquement par le workflow GitHub Actions "Generate Admin Hash".
-// Ne pas modifier à la main.
-export const ADMIN_HASH = "${HASH}";
-EOT
+          mkdir -p src
+          {
+            printf '%s\n' "// Ce fichier est généré automatiquement par le workflow GitHub Actions \"Generate Admin Hash\"."
+            printf '%s\n' "// Ne pas modifier à la main."
+            printf '%s\n' "export const ADMIN_HASH = \"${HASH}\";"
+          } > src/admin-config.js
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
 
       - name: Commit admin hash update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update admin hash"
-          file_pattern: admin-hash.js
+          file_pattern: src/admin-config.js


### PR DESCRIPTION
## Summary
- ensure ADMIN_PASSWORD is validated, hashed, and written to src/admin-config.js
- add Node.js setup plus install and build steps prior to deployment
- deploy the built site to GitHub Pages with peaceiris/actions-gh-pages@v3

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d312aa518483338aac9393501f154a