### PR TITLE
Fix admin hash initialization flow

### DIFF
--- a/.github/workflows/generate-admin-hash.yml
+++ b/.github/workflows/generate-admin-hash.yml
@@ -27,12 +27,16 @@ jobs:
         run: |
           set -euo pipefail
           HASH=$(printf "%s" "${ADMIN_PASSWORD}" | sha256sum | cut -d' ' -f1)
-          mkdir -p src
           {
             printf '%s\n' "// Ce fichier est généré automatiquement par le workflow GitHub Actions \"Generate Admin Hash\"."
             printf '%s\n' "// Ne pas modifier à la main."
-            printf '%s\n' "export const ADMIN_HASH = \"${HASH}\";"
-          } > src/admin-config.js
+            printf '%s\n' "(function applyAdminHash() {"
+            printf '%s\n' "  if (typeof window === \"undefined\") {"
+            printf '%s\n' "    return;"
+            printf '%s\n' "  }"
+            printf '%s\n' "  window.__HP_ADMIN_HASH__ = \"${HASH}\";"
+            printf '%s\n' "})();"
+          } > admin-config.js
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -51,8 +55,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
 
-      - name: Commit admin hash update
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore: update admin hash"
-          file_pattern: src/admin-config.js
+        - name: Commit admin hash update
+          uses: stefanzweifel/git-auto-commit-action@v5
+          with:
+            commit_message: "chore: update admin hash"
+            file_pattern: admin-config.js

--- a/admin-config.js
+++ b/admin-config.js
@@ -1,0 +1,16 @@
+// Ce fichier peut être généré automatiquement par le workflow GitHub Actions
+// « Generate Admin Hash ». Il définit la valeur du hash administrateur au
+// runtime via la variable globale `window.__HP_ADMIN_HASH__`.
+//
+// En local, vous pouvez ajuster la valeur manuellement ou laisser le workflow
+// la remplacer lors du déploiement.
+(function applyAdminHash() {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const current = window.__HP_ADMIN_HASH__;
+  if (typeof current === "string" && current && current !== "__ADMIN_HASH_PLACEHOLDER__") {
+    return;
+  }
+  window.__HP_ADMIN_HASH__ = "__ADMIN_HASH_PLACEHOLDER__";
+})();

--- a/admin-hash.js
+++ b/admin-hash.js
@@ -1,3 +1,42 @@
-// Ce fichier est généré automatiquement par le workflow GitHub Actions "Generate Admin Hash".
-// Valeur de repli locale : remplacez-la via le workflow.
-export const ADMIN_HASH = "__ADMIN_HASH_PLACEHOLDER__";
+// Ce module expose la valeur du hash administrateur.
+//
+// Par défaut, il se replie sur la valeur placeholder. Lors du déploiement, le
+// workflow « Generate Admin Hash » génère `admin-config.js` qui définit la
+// variable globale `window.__HP_ADMIN_HASH__`. Ce module récupère la valeur à
+// chaque lecture afin de s'adapter même si le script de configuration est
+// chargé après coup.
+
+const PLACEHOLDER_VALUE = "__ADMIN_HASH_PLACEHOLDER__";
+
+function isMeaningful(value) {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return trimmed !== PLACEHOLDER_VALUE;
+}
+
+function readFromWindow() {
+  if (typeof window === "undefined") return null;
+  const value = window.__HP_ADMIN_HASH__;
+  return isMeaningful(value) ? value.trim() : null;
+}
+
+function readFromMeta() {
+  if (typeof document === "undefined") return null;
+  const meta = document.querySelector('meta[name="hp:admin-hash"]');
+  if (!meta) return null;
+  return isMeaningful(meta.content) ? meta.content.trim() : null;
+}
+
+export function resolveAdminHash() {
+  return readFromWindow() ?? readFromMeta() ?? PLACEHOLDER_VALUE;
+}
+
+export function isAdminHashPlaceholder(value = resolveAdminHash()) {
+  return !value || value === PLACEHOLDER_VALUE;
+}
+
+export const ADMIN_HASH_PLACEHOLDER = PLACEHOLDER_VALUE;
+
+// Valeur actuelle (lecture à l'import, conservée pour rétro-compatibilité).
+export const ADMIN_HASH = resolveAdminHash();

--- a/admin.html
+++ b/admin.html
@@ -67,6 +67,7 @@
       <noscript>Activez JavaScript pour accéder à l’espace administrateur.</noscript>
     </div>
   </main>
+  <script src="admin-config.js"></script>
   <script type="module" src="admin-auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- resolve the admin hash dynamically so it can be supplied by the generated config script
- make the admin login wait for the configured hash and compare against it during prompts
- load the new `admin-config.js` helper and update the workflow to generate it during deployments

## Testing
- node tests/weekDateRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d31455ede483338eb5f097e20382e3