### PR TITLE
Fix generate admin hash workflow and improve admin login UX

### DIFF
--- a/.github/workflows/generate-admin-hash.yml
+++ b/.github/workflows/generate-admin-hash.yml
@@ -9,6 +9,8 @@ jobs:
   build-admin-hash:
     if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
     steps:
@@ -38,25 +40,28 @@ jobs:
             printf '%s\n' "})();"
           } > admin-config.js
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Commit admin hash update
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          node-version: '20'
+          commit_message: "chore: update admin hash"
+          file_pattern: admin-config.js
 
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build project
-        run: npm run build
+      - name: Préparer les fichiers statiques
+        run: |
+          rm -rf build
+          mkdir build
+          rsync -av \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            --exclude 'build/' \
+            --exclude 'functions/' \
+            --exclude 'tests/' \
+            --exclude 'firebase.json' \
+            --exclude 'firestore.rules' \
+            ./ build/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-
-        - name: Commit admin hash update
-          uses: stefanzweifel/git-auto-commit-action@v5
-          with:
-            commit_message: "chore: update admin hash"
-            file_pattern: admin-config.js

--- a/admin.html
+++ b/admin.html
@@ -63,7 +63,7 @@
     <div class="card">
       <h1>Zone administrateur</h1>
       <p id="admin-login-status">Initialisation…</p>
-      <p class="helper">Vous serez redirigé après vérification.</p>
+      <p id="admin-login-helper" class="helper">Vous serez redirigé après vérification.</p>
       <noscript>Activez JavaScript pour accéder à l’espace administrateur.</noscript>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- repair the Generate Admin Hash workflow so it validates secrets, commits the generated file, prepares static assets, and deploys to GitHub Pages
- enhance the admin authentication script to keep users on the login screen when the hash is missing or verification fails and surface clearer helper messaging
- tag the helper paragraph in the admin page so its messaging can be updated dynamically

## Testing
- not run (static site / no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d317b81cbc8333b2c6e626cce815fb