### PR TITLE
Ensure root URL only redirects to admin when on base hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,16 @@
 <head>
   <script>
     // Redirection automatique vers l'espace administrateur lorsqu'on arrive sur l'URL racine
-    window.location.replace('admin.html');
+    (function redirectToAdminOnRoot() {
+      const { hash } = window.location;
+      const isRootHash = hash === "" || hash === "#" || hash === "#/";
+      if (!isRootHash) {
+        return;
+      }
+
+      const target = new URL("admin.html", window.location.href);
+      window.location.replace(target.toString());
+    })();
   </script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- redirect the root URL to admin.html only when no hash is present
- avoid re-triggering the login redirect when already on the admin section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d31ba6fff88333b676b843d4531183