### PR TITLE
Refine user actions menu and priority visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,18 @@
     body { font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     body{ background:var(--page-bg); color:var(--text); }
 
+    .sr-only {
+      position:absolute;
+      width:1px;
+      height:1px;
+      padding:0;
+      margin:-1px;
+      overflow:hidden;
+      clip:rect(0,0,0,0);
+      white-space:nowrap;
+      border:0;
+    }
+
     /* Cards blanches, coins 2xl, ombre douce */
     .card{ background:var(--card-bg); border:1px solid #E5E7EB; border-radius:1rem; box-shadow: 0 8px 24px rgba(16,24,40,.06); }
 
@@ -219,16 +231,16 @@
       gap:1.1rem;
     }
     .daily-consigne {
-      background:transparent;
-      border-radius:0;
-      border:none;
-      box-shadow:none;
-      padding:0 0 1.2rem;
+      background:#fff;
+      border-radius:1rem;
+      border:1px solid rgba(148,163,184,.22);
+      box-shadow:0 6px 16px rgba(15,23,42,.04);
+      padding:1rem 1.2rem;
       display:grid;
       gap:.75rem;
-      border-bottom:1px solid rgba(148,163,184,.18);
+      transition:background .2s ease,border-color .2s ease,box-shadow .2s ease;
     }
-    .daily-consigne:last-child { border-bottom:none; padding-bottom:0; }
+    .daily-consigne:last-child { border-bottom:none; }
     .daily-consigne__top {
       display:flex;
       flex-wrap:wrap;
@@ -267,26 +279,45 @@
       background:var(--accent-50);
       border-radius:.5rem;
     }
-    .daily-consigne__actions .text-red-600 {
-      color:#b91c1c;
+
+    .priority-surface {
+      position:relative;
     }
-    .daily-consigne__actions .text-red-600:hover,
-    .daily-consigne__actions .text-red-600:focus-visible {
-      color:#991b1b;
-      background:#fee2e2;
+    .priority-surface-high {
+      background:#fef2f2;
+      border-color:#fecaca;
+      box-shadow:0 6px 18px rgba(248,113,113,.18);
+    }
+    .priority-surface-medium {
+      background:#ffffff;
+      border-color:#e2e8f0;
+    }
+    .priority-surface-low {
+      background:#f8fafc;
+      border-color:#e2e8f0;
+      box-shadow:0 4px 14px rgba(148,163,184,.12);
     }
 
-    /* Pastilles de priorité */
-    .prio-chip {
-      display:inline-flex; align-items:center; gap:.4rem;
-      padding:.15rem .5rem; border-radius:999px;
-      font-size:.75rem; border:1px solid transparent;
+    .consigne-card.priority-surface-high {
+      background:#fef2f2;
+      border-color:#fecaca;
     }
-    .prio-high   { background:#FEE2E2; border-color:#FCA5A5; color:#B91C1C; } /* rouge doux */
-    .prio-medium { background:#FEF3C7; border-color:#FCD34D; color:#92400E; } /* ambre doux */
-    .prio-low    { background:#E0F2FE; border-color:#BAE6FD; color:#075985; } /* bleu doux */
+    .consigne-card.priority-surface-low {
+      background:#f8fafc;
+      border-color:#e2e8f0;
+    }
 
     .btn-saved{ background:#22C55E; } /* vert doux rapide pour le flash */
+
+    .user-actions{ position:relative; display:flex; align-items:center; }
+    .user-actions__trigger{ border:1px solid #E2E8F0; background:#fff; color:#475569; border-radius:999px; width:2.25rem; height:2.25rem; display:inline-flex; align-items:center; justify-content:center; font-size:1.25rem; transition:background .15s ease,border-color .15s ease,color .15s ease; }
+    .user-actions__trigger:hover,
+    .user-actions__trigger:focus-visible{ background:var(--accent-50); border-color:var(--accent-200); outline:none; color:#0f172a; }
+    .user-actions__panel{ position:absolute; right:0; top:calc(100% + .5rem); display:flex; flex-direction:column; min-width:16rem; background:#fff; border:1px solid #E2E8F0; border-radius:1rem; box-shadow:0 20px 40px rgba(15,23,42,.16); padding:.5rem; z-index:40; }
+    .user-actions__item{ width:100%; text-align:left; background:none; border:none; padding:.65rem .85rem; border-radius:.75rem; font:inherit; color:inherit; display:flex; align-items:center; gap:.5rem; cursor:pointer; transition:background .15s ease,color .15s ease; }
+    .user-actions__item:hover,
+    .user-actions__item:focus-visible{ background:var(--accent-50); outline:none; }
+    .user-actions__separator{ height:1px; width:100%; background:#e2e8f0; margin:.25rem 0; }
 
     /* Objectifs */
     .goal-header{ display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap; margin-bottom:12px; }
@@ -305,7 +336,7 @@
     .goal-week__header{ display:flex; align-items:center; justify-content:space-between; gap:.5rem; margin-bottom:.45rem; }
     .goal-week__label{ font-size:.82rem; }
     .goal-week__add{ padding:.25rem .75rem; font-size:.78rem; border-radius:999px; }
-    .goal-row{ display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 10px; border-radius:12px; transition:background .15s ease, box-shadow .15s ease; border-left:4px solid transparent; }
+    .goal-row{ display:flex; flex-direction:column; align-items:flex-start; gap:.75rem; padding:10px 12px; border-radius:12px; transition:background .15s ease, box-shadow .15s ease; border-left:4px solid transparent; }
     .goal-row:hover{ box-shadow:0 6px 14px rgba(15,23,42,.08); }
     .goal-row--positive{ background:#ecfdf5; border-left-color:#22c55e; }
     .goal-row--neutral{ background:#fefce8; border-left-color:#fbbf24; }
@@ -314,13 +345,14 @@
     .goal-row--editable{ cursor:pointer; }
     .goal-row--editable .goal-quick,
     .goal-row--editable .goal-quick *{ cursor:auto; }
-    .goal-title{ flex:1; }
+    .goal-title{ flex:1; width:100%; }
     .goal-title__button{ display:flex; flex-direction:column; align-items:flex-start; gap:2px; width:100%; background:none; border:none; padding:0; font:inherit; color:inherit; text-align:left; cursor:pointer; }
     .goal-title__button:hover .goal-title__text{ text-decoration:underline; }
     .goal-title__button:focus-visible{ outline:2px solid var(--accent-400); outline-offset:2px; border-radius:6px; }
     .goal-title__text{ font-weight:600; }
     .goal-title__subtitle{ color:var(--muted); font-size:.75rem; }
-    .goal-quick{ min-width:140px; }
+    .goal-quick{ width:100%; }
+    .goal-quick select{ width:100%; }
     .goal-empty{ padding:1rem; border-radius:.75rem; background:var(--accent-50); }
     .select-compact{ font-size:.95rem; padding:4px 8px; border-radius:10px; border:1px solid #e5e7eb; background:#fff; }
     .select-compact:focus{ outline:none; border-color:var(--accent-400); box-shadow:0 0 0 3px var(--accent-50); }
@@ -365,7 +397,7 @@
     .practice-dashboard__row-indicator{ width:.45rem; height:2.5rem; border-radius:999px; background:var(--row-accent,#CBD5F5); flex-shrink:0; }
     .practice-dashboard__row-info{ display:flex; flex-direction:column; gap:.35rem; }
     .practice-dashboard__consigne-name{ font-weight:600; font-size:.95rem; color:#0f172a; }
-    .practice-dashboard__row-meta{ font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; color:#94A3B8; }
+    .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
     .practice-dashboard__matrix tbody td{ padding:.45rem .35rem; text-align:center; }
     .practice-dashboard__matrix tbody tr:nth-child(even){ background:rgba(241,245,249,.35); }
     .practice-dashboard__cell{ position:relative; width:100%; min-width:3.5rem; padding:.55rem .35rem; border-radius:.75rem; border:1px solid transparent; font-weight:600; font-size:.85rem; background:#F8FAFC; color:#0f172a; display:flex; align-items:center; justify-content:center; transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease; }
@@ -434,8 +466,28 @@
           <button class="tab" data-route="#/practice"><span>⚡</span><span>Pratique</span></button>
           <button class="tab" data-route="#/goals"><span>🎯</span><span>Objectifs</span></button>
         </nav>
-        <div class="hidden w-full flex-col gap-2 sm:hidden" id="mobile-actions">
-          <button type="button" class="btn btn-primary" id="install-app-button">Ajouter à l’écran d’accueil</button>
+        <div class="user-actions hidden" id="user-actions" aria-hidden="true">
+          <button type="button" class="user-actions__trigger" id="user-actions-trigger" aria-haspopup="true" aria-expanded="false" title="Actions">
+            ⋮
+          </button>
+          <div class="user-actions__panel hidden" id="user-actions-panel" role="menu">
+            <button type="button"
+                    class="user-actions__item"
+                    id="user-actions-notifications"
+                    data-notif-toggle
+                    data-uid=""
+                    data-enabled="0"
+                    role="menuitem">
+              🔔 Activer les notifications
+            </button>
+            <div class="user-actions__separator" role="presentation"></div>
+            <button type="button"
+                    class="user-actions__item hidden"
+                    id="install-app-button"
+                    role="menuitem">
+              📱 Ajouter à l’écran d’accueil
+            </button>
+          </div>
         </div>
       </div>
     </header>
@@ -486,9 +538,8 @@
   </script>
   <script>
     (function setupInstallButton() {
-      const actions = document.getElementById("mobile-actions");
       const installButton = document.getElementById("install-app-button");
-      if (!installButton || !actions) {
+      if (!installButton) {
         return;
       }
 
@@ -498,13 +549,13 @@
 
       function showButton() {
         if (isStandalone) return;
-        actions.classList.remove("hidden");
         installButton.classList.remove("hidden");
+        installButton.disabled = false;
       }
 
       function hideButton() {
         installButton.classList.add("hidden");
-        actions.classList.add("hidden");
+        installButton.disabled = true;
       }
 
       hideButton();
@@ -520,7 +571,17 @@
         hideButton();
       });
 
+      if (isiOS && !isStandalone) {
+        installButton.classList.remove("hidden");
+        installButton.textContent = "📱 Ajouter via Safari";
+        installButton.disabled = false;
+      }
+
       installButton.addEventListener("click", async () => {
+        if (typeof window.__closeUserActionsMenu === "function") {
+          window.__closeUserActionsMenu();
+        }
+
         if (deferredPrompt) {
           deferredPrompt.prompt();
           try {

--- a/modes.js
+++ b/modes.js
@@ -75,11 +75,24 @@ function srBadge(c){
             aria-pressed="${enabled}" title="${title}">⏳</button>`;
 }
 
+function priorityTone(p) {
+  const n = Number(p);
+  if (!Number.isFinite(n)) return "medium";
+  if (n <= 1) return "high";
+  if (n >= 3) return "low";
+  return "medium";
+}
+
+function priorityLabelFromTone(tone) {
+  if (tone === "high") return "haute";
+  if (tone === "low") return "basse";
+  return "moyenne";
+}
+
 function prioChip(p) {
-  const n = Number(p)||2;
-  const cls = n===1 ? "prio-chip prio-high" : n===2 ? "prio-chip prio-medium" : "prio-chip prio-low";
-  const lbl = n===1 ? "Haute" : n===2 ? "Moyenne" : "Basse";
-  return `<span class="${cls}" title="Priorité ${lbl}">${lbl}</span>`;
+  const tone = priorityTone(p);
+  const lbl = priorityLabelFromTone(tone);
+  return `<span class="sr-only" data-priority="${tone}">Priorité ${lbl}</span>`;
 }
 
 function smallBtn(label, cls = "") {
@@ -813,7 +826,7 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
                 <span class="practice-dashboard__row-indicator" aria-hidden="true"></span>
                 <div class="practice-dashboard__row-info">
                   <span class="practice-dashboard__consigne-name">${escapeHtml(stat.name)}</span>
-                  <span class="practice-dashboard__row-meta">${escapeHtml(stat.priorityLabel)}</span>
+                  <span class="practice-dashboard__row-meta sr-only">Priorité ${escapeHtml(stat.priorityLabel)}</span>
                 </div>
               </div>
             </th>`;
@@ -1398,7 +1411,7 @@ function consigneActions() {
     <div class="daily-consigne__actions" role="group" aria-label="Actions">
       ${smallBtn("Historique", "js-histo")}
       ${smallBtn("Modifier", "js-edit")}
-      ${smallBtn("Supprimer", "js-del text-red-600")}
+      ${smallBtn("Supprimer", "js-del")}
     </div>
   `;
 }
@@ -1938,8 +1951,9 @@ async function renderPractice(ctx, root, _opts = {}) {
     form.innerHTML = "";
 
     const makeItem = (c) => {
+      const tone = priorityTone(c.priority);
       const el = document.createElement("div");
-      el.className = "consigne-card card p-3 space-y-3";
+      el.className = `consigne-card card p-3 space-y-3 priority-surface priority-surface-${tone}`;
       el.dataset.id = c.id;
       el.setAttribute("draggable", "true");
       el.innerHTML = `
@@ -2206,7 +2220,8 @@ async function renderDaily(ctx, root, opts = {}) {
   const renderItemCard = (item) => {
     const previous = previousAnswers?.get(item.id);
     const itemCard = document.createElement("div");
-    itemCard.className = "daily-consigne";
+    const tone = priorityTone(item.priority);
+    itemCard.className = `daily-consigne priority-surface priority-surface-${tone}`;
     itemCard.innerHTML = `
       <div class="daily-consigne__top">
         <div class="daily-consigne__title">


### PR DESCRIPTION
## Summary
- add a three-dot header menu to group the notification toggle and install shortcut for each user, remove the admin-side notification button, and update sidebar messaging
- restyle daily and practice cards plus goals to rely on priority-based surface colors and give long descriptions more room
- keep accessibility for priorities with sr-only labels while softening delete actions to match other buttons

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d39df811808333ba45da3499c0fee1