### PR TITLE
Align weekly segments to Monday starts

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -663,46 +663,22 @@ function monthWeekSegments(monthKey) {
   if (!totalDays) return [];
   const firstDay = new Date(year, month - 1, 1);
   const firstWeekday = mondayIndexFromSundayIndex(firstDay.getDay());
-  const span = totalDays + firstWeekday;
-  const rawCount = Math.max(4, Math.ceil(span / 7));
-  const rawWeeks = [];
-  for (let i = 0; i < rawCount; i += 1) {
-    const rawStart = 1 - firstWeekday + i * 7;
-    const rawEnd = rawStart + 6;
-    const startDay = Math.max(1, rawStart);
-    const endDay = Math.min(totalDays, rawEnd);
-    if (startDay > endDay) {
-      continue;
-    }
-    rawWeeks.push({ startDay, endDay });
-  }
-  if (!rawWeeks.length) {
-    return [];
-  }
-  while (rawWeeks.length > 4) {
-    const first = rawWeeks[0];
-    const last = rawWeeks[rawWeeks.length - 1];
-    const firstLength = first.endDay - first.startDay + 1;
-    const lastLength = last.endDay - last.startDay + 1;
-    if (firstLength <= lastLength) {
-      rawWeeks[1].startDay = first.startDay;
-      rawWeeks.shift();
-    } else {
-      rawWeeks[rawWeeks.length - 2].endDay = last.endDay;
-      rawWeeks.pop();
-    }
-  }
-  return rawWeeks.map((week, idx) => {
-    const start = new Date(year, month - 1, week.startDay);
-    const end = new Date(year, month - 1, week.endDay);
-    return {
-      index: idx + 1,
+  const baseStartDay = 1 - firstWeekday;
+  const segments = [];
+  for (let i = 0; i < 4; i += 1) {
+    const startDay = baseStartDay + i * 7;
+    const endDay = startDay + 6;
+    const start = new Date(year, month - 1, startDay);
+    const end = new Date(year, month - 1, endDay);
+    segments.push({
+      index: i + 1,
       start,
       end,
-      startDay: week.startDay,
-      endDay: week.endDay,
-    };
-  });
+      startDay,
+      endDay,
+    });
+  }
+  return segments;
 }
 
 function weeksOf(monthKey) {

--- a/tests/weekDateRange.test.js
+++ b/tests/weekDateRange.test.js
@@ -38,16 +38,36 @@ function runTests() {
   assert(augustRange, "La première semaine d’août 2020 doit être définie");
   assertEqual(
     augustRange.label,
-    "Semaine du 01 au 09 août",
+    "Semaine du 27 juillet au 02 août",
     "Libellé de la première semaine d’août 2020 incorrect",
+  );
+  assertEqual(
+    augustRange.start.getDay(),
+    1,
+    "La première semaine d’août 2020 doit commencer un lundi",
+  );
+  assertEqual(
+    augustRange.end.getDay(),
+    0,
+    "La première semaine d’août 2020 doit se terminer un dimanche",
   );
 
   const octoberRange = weekDateRange("2023-10", 4);
   assert(octoberRange, "La quatrième semaine d’octobre 2023 doit être définie");
   assertEqual(
     octoberRange.label,
-    "Semaine du 23 au 31 octobre",
+    "Semaine du 16 au 22 octobre",
     "Libellé de la dernière semaine d’octobre 2023 incorrect",
+  );
+  assertEqual(
+    octoberRange.start.getDay(),
+    1,
+    "La quatrième semaine d’octobre 2023 doit commencer un lundi",
+  );
+  assertEqual(
+    octoberRange.end.getDay(),
+    0,
+    "La quatrième semaine d’octobre 2023 doit se terminer un dimanche",
   );
 
   assertEqual(
@@ -57,8 +77,8 @@ function runTests() {
   );
   assertEqual(
     weekOfMonthFromDate(new Date("2020-08-10")),
-    2,
-    "Le 10 août 2020 devrait appartenir à la deuxième semaine",
+    3,
+    "Le 10 août 2020 devrait appartenir à la troisième semaine",
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure monthly week segments always start on Monday and cover 7-day spans even if they extend across adjacent months
- update calendar week tests to match the new Monday-first ranges and verify start/end weekdays

## Testing
- node tests/weekDateRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3a788902c833399f98904f6357cf9