### PR TITLE
Aligner les semaines des objectifs sur lundi-dimanche

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -665,13 +665,12 @@ function monthWeekSegments(monthKey) {
   const firstWeekday = mondayIndexFromSundayIndex(firstDay.getDay());
   const baseStartDay = 1 - firstWeekday;
   const segments = [];
-  for (let i = 0; i < 4; i += 1) {
-    const startDay = baseStartDay + i * 7;
+  for (let index = 1, startDay = baseStartDay; startDay <= totalDays; index += 1, startDay += 7) {
     const endDay = startDay + 6;
     const start = new Date(year, month - 1, startDay);
     const end = new Date(year, month - 1, endDay);
     segments.push({
-      index: i + 1,
+      index,
       start,
       end,
       startDay,

--- a/tests/weekDateRange.test.js
+++ b/tests/weekDateRange.test.js
@@ -32,7 +32,10 @@ function assertEqual(actual, expected, message) {
 
 function runTests() {
   const aprilWeeks = weeksOf("2023-04");
-  assertEqual(JSON.stringify(aprilWeeks), JSON.stringify([1, 2, 3, 4]), "Avril 2023 devrait compter 4 semaines");
+  assertEqual(JSON.stringify(aprilWeeks), JSON.stringify([1, 2, 3, 4, 5]), "Avril 2023 devrait compter 5 semaines");
+
+  const mayWeeks = weeksOf("2021-05");
+  assertEqual(JSON.stringify(mayWeeks), JSON.stringify([1, 2, 3, 4, 5, 6]), "Mai 2021 devrait compter 6 semaines");
 
   const augustRange = weekDateRange("2020-08", 1);
   assert(augustRange, "La première semaine d’août 2020 doit être définie");
@@ -68,6 +71,42 @@ function runTests() {
     octoberRange.end.getDay(),
     0,
     "La quatrième semaine d’octobre 2023 doit se terminer un dimanche",
+  );
+
+  const aprilLastRange = weekDateRange("2023-04", 5);
+  assert(aprilLastRange, "La cinquième semaine d’avril 2023 doit être définie");
+  assertEqual(
+    aprilLastRange.label,
+    "Semaine du 24 au 30 avril",
+    "Libellé de la cinquième semaine d’avril 2023 incorrect",
+  );
+  assertEqual(
+    aprilLastRange.start.getDay(),
+    1,
+    "La cinquième semaine d’avril 2023 doit commencer un lundi",
+  );
+  assertEqual(
+    aprilLastRange.end.getDay(),
+    0,
+    "La cinquième semaine d’avril 2023 doit se terminer un dimanche",
+  );
+
+  const augustLastRange = weekDateRange("2020-08", 6);
+  assert(augustLastRange, "La sixième semaine d’août 2020 doit être définie");
+  assertEqual(
+    augustLastRange.label,
+    "Semaine du 31 août au 06 septembre",
+    "Libellé de la sixième semaine d’août 2020 incorrect",
+  );
+  assertEqual(
+    augustLastRange.start.getDay(),
+    1,
+    "La sixième semaine d’août 2020 doit commencer un lundi",
+  );
+  assertEqual(
+    augustLastRange.end.getDay(),
+    0,
+    "La sixième semaine d’août 2020 doit se terminer un dimanche",
   );
 
   assertEqual(


### PR DESCRIPTION
## Summary
- recalculer dynamiquement les segments hebdomadaires pour couvrir tout le mois du lundi au dimanche
- ajuster les tests des plages hebdomadaires pour prendre en compte les mois à 5 ou 6 semaines

## Testing
- node tests/weekDateRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3aa6ab8108333927341f5cd5e2669