### PR TITLE
Ensure Add to Home uses user route and stays visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,6 +581,18 @@
 
       let deferredPrompt = null;
 
+      function rememberCurrentInstallTarget() {
+        const api = window.__appInstallTarget;
+        if (!api || typeof api.save !== "function") {
+          return;
+        }
+        try {
+          api.save(window.location.hash || "");
+        } catch (error) {
+          console.warn("[install] target:remember", error);
+        }
+      }
+
       function showButton({ label } = {}) {
         if (isStandalone) return;
         installButton.textContent = label || defaultLabel;
@@ -602,8 +614,9 @@
       });
 
       window.addEventListener("appinstalled", () => {
+        rememberCurrentInstallTarget();
         deferredPrompt = null;
-        hideButton();
+        showButton({ label: defaultLabel });
       });
 
       if (isiOS && !isStandalone) {
@@ -613,6 +626,7 @@
       }
 
       installButton.addEventListener("click", async () => {
+        rememberCurrentInstallTarget();
         if (typeof window.__closeUserActionsMenu === "function") {
           window.__closeUserActionsMenu();
         }
@@ -623,7 +637,7 @@
             const choice = await deferredPrompt.userChoice;
             deferredPrompt = null;
             if (choice?.outcome === "accepted") {
-              hideButton();
+              showButton({ label: defaultLabel });
             }
           } catch (error) {
             console.warn("[install] prompt", error);


### PR DESCRIPTION
## Summary
- persist the selected user route as the preferred install target and reuse it when no hash is present
- expose helpers to store that target and hook the Add to Home Screen button up to remember the current page
- keep the install button visible after installation while reusing the standard label

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3bd659f988333a88b4b32839dcbc9