### PR TITLE
Préserve la route utilisateur lors de l'installation PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,47 @@
         return;
       }
 
+      const isStandaloneDisplay = (() => {
+        try {
+          const mediaQueryMatch =
+            typeof window.matchMedia === "function" && window.matchMedia("(display-mode: standalone)").matches;
+          return mediaQueryMatch || window.navigator.standalone === true;
+        } catch (error) {
+          return window.navigator.standalone === true;
+        }
+      })();
+
+      const INSTALL_TARGET_STORAGE_KEY = "hp::install::target";
+
+      function readStoredInstallTarget() {
+        try {
+          const storage = window.localStorage;
+          if (!storage) return null;
+          const raw = storage.getItem(INSTALL_TARGET_STORAGE_KEY);
+          if (!raw || typeof raw !== "string") return null;
+          const trimmed = raw.trim();
+          if (!/^#\/u\//.test(trimmed)) return null;
+          const [rawPath = "", searchPart = ""] = trimmed.split("?");
+          const segments = rawPath.replace(/^#\/+/g, "").split("/");
+          if (!segments[1]) return null; // nécessite au moins un UID
+          if (segments.length < 3 || !segments[2]) {
+            segments[2] = "daily";
+          }
+          const normalizedHash = `#/${segments.filter(Boolean).join("/")}`;
+          return searchPart ? `${normalizedHash}?${searchPart}` : normalizedHash;
+        } catch (error) {
+          console.warn("[install] target:read", error);
+          return null;
+        }
+      }
+
+      const storedTarget = readStoredInstallTarget();
+      if (storedTarget && isStandaloneDisplay) {
+        const normalized = storedTarget.replace(/^#/, "");
+        window.location.hash = normalized;
+        return;
+      }
+
       const target = new URL("admin.html", window.location.href);
       window.location.replace(target.toString());
     })();


### PR DESCRIPTION
## Summary
- conserve le comportement de redirection vers l'écran utilisateur lorsqu'on lance l'application installée
- mémorise l'URL utilisateur depuis le stockage et l'applique uniquement en mode standalone

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3c4ff9b5c83338066cdb4c90507fc