### PR TITLE
Replace install help link with direct download button

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
     .install-banner__text{ display:flex; flex-direction:column; gap:2px; }
     .install-banner__title{ font-weight:600; }
     .install-banner__subtitle{ color:var(--muted); font-size:.8rem; }
-    .install-banner__action{ display:inline-flex; align-items:center; gap:.25rem; font-weight:600; color:var(--accent-700); text-decoration:none; font-size:.82rem; flex-shrink:0; }
+    .install-banner__action{ display:inline-flex; align-items:center; gap:.25rem; font-weight:600; color:var(--accent-700); text-decoration:none; font-size:.82rem; flex-shrink:0; background:none; border:0; cursor:pointer; padding:0; font-family:inherit; }
     .install-banner__action:hover,
     .install-banner__action:focus-visible{ text-decoration:underline; outline:none; }
 
@@ -519,7 +519,7 @@
               <span class="install-banner__subtitle">Ajoutez-la à votre écran d’accueil pour un accès rapide.</span>
             </div>
           </div>
-          <a class="install-banner__action" href="https://support.google.com/chrome/answer/9658361?hl=fr" target="_blank" rel="noreferrer">Comment faire&nbsp;?</a>
+          <button type="button" class="install-banner__action" id="install-banner-action" data-install-trigger>Télécharger</button>
         </div>
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h1 class="text-lg sm:text-xl font-semibold pr-12 sm:pr-0">
@@ -552,6 +552,7 @@
             <button type="button"
                     class="user-actions__item hidden"
                     id="install-app-button"
+                    data-install-trigger
                     role="menuitem">
               📱 Ajouter à l’écran d’accueil
             </button>
@@ -626,13 +627,24 @@
   </script>
   <script>
     (function setupInstallButton() {
-      const installButton = document.getElementById("install-app-button");
       const installBanner = document.getElementById("install-banner");
-      if (!installButton) {
+      const installButtons = Array.from(document.querySelectorAll("[data-install-trigger]"));
+      if (installButtons.length === 0) {
+        if (installBanner) {
+          installBanner.classList.add("hidden");
+          installBanner.setAttribute("aria-hidden", "true");
+        }
         return;
       }
 
-      const defaultLabel = installButton.textContent.trim() || "📱 Ajouter à l’écran d’accueil";
+      const buttonDefaults = new Map();
+      installButtons.forEach((button) => {
+        const text = (button.textContent || "").trim();
+        buttonDefaults.set(button, text);
+      });
+
+      const primaryButton = document.getElementById("install-app-button") || installButtons[0];
+      const primaryDefaultLabel = (buttonDefaults.get(primaryButton) || "📱 Ajouter à l’écran d’accueil");
       const supportsMatchMedia = typeof window.matchMedia === "function";
       const mediaMatches = (query) => (supportsMatchMedia ? window.matchMedia(query).matches : false);
       const isStandalone = mediaMatches("(display-mode: standalone)") || window.navigator.standalone === true;
@@ -671,14 +683,20 @@
 
       function showButton({ label } = {}) {
         if (isStandalone) return;
-        installButton.textContent = label || defaultLabel;
-        installButton.classList.remove("hidden");
-        installButton.disabled = false;
+        installButtons.forEach((button) => {
+          const defaultLabel = buttonDefaults.get(button) || primaryDefaultLabel;
+          const nextLabel = label && button === primaryButton ? label : defaultLabel;
+          button.textContent = nextLabel;
+          button.classList.remove("hidden");
+          button.disabled = false;
+        });
       }
 
       function hideButton() {
-        installButton.classList.add("hidden");
-        installButton.disabled = true;
+        installButtons.forEach((button) => {
+          button.classList.add("hidden");
+          button.disabled = true;
+        });
       }
 
       hideButton();
@@ -691,53 +709,55 @@
       window.addEventListener("beforeinstallprompt", (event) => {
         event.preventDefault();
         deferredPrompt = event;
-        showButton({ label: defaultLabel });
+        showButton({ label: primaryDefaultLabel });
       });
 
       window.addEventListener("appinstalled", () => {
         rememberCurrentInstallTarget();
         deferredPrompt = null;
-        showButton({ label: defaultLabel });
+        showButton({ label: primaryDefaultLabel });
         hideBanner();
       });
 
       if (isiOS && !isStandalone) {
         showButton({ label: "📱 Ajouter via Safari" });
       } else if (isMobileDevice && !isStandalone) {
-        showButton({ label: defaultLabel });
+        showButton({ label: primaryDefaultLabel });
       }
 
-      installButton.addEventListener("click", async () => {
-        rememberCurrentInstallTarget();
-        if (typeof window.__closeUserActionsMenu === "function") {
-          window.__closeUserActionsMenu();
-        }
-
-        if (deferredPrompt) {
-          deferredPrompt.prompt();
-          try {
-            const choice = await deferredPrompt.userChoice;
-            deferredPrompt = null;
-            if (choice?.outcome === "accepted") {
-              showButton({ label: defaultLabel });
-            }
-          } catch (error) {
-            console.warn("[install] prompt", error);
+      installButtons.forEach((button) => {
+        button.addEventListener("click", async () => {
+          rememberCurrentInstallTarget();
+          if (typeof window.__closeUserActionsMenu === "function") {
+            window.__closeUserActionsMenu();
           }
-          return;
-        }
 
-        if (isiOS && !isStandalone) {
-          alert("Pour ajouter cette app à l’écran d’accueil, ouvre le menu de partage Safari puis choisis « Ajouter à l’écran d’accueil ».");
-          return;
-        }
+          if (deferredPrompt) {
+            deferredPrompt.prompt();
+            try {
+              const choice = await deferredPrompt.userChoice;
+              deferredPrompt = null;
+              if (choice?.outcome === "accepted") {
+                showButton({ label: primaryDefaultLabel });
+              }
+            } catch (error) {
+              console.warn("[install] prompt", error);
+            }
+            return;
+          }
 
-        if ((isAndroid || isMobileDevice) && !isStandalone) {
-          alert("Pour installer cette app, utilise le menu du navigateur (⋮) puis sélectionne « Ajouter à l’écran d’accueil ».");
-          return;
-        }
+          if (isiOS && !isStandalone) {
+            alert("Pour ajouter cette app à l’écran d’accueil, ouvre le menu de partage Safari puis choisis « Ajouter à l’écran d’accueil ».");
+            return;
+          }
 
-        alert("Utilise les options du navigateur pour ajouter cette page à l’écran d’accueil.");
+          if ((isAndroid || isMobileDevice) && !isStandalone) {
+            alert("Pour installer cette app, utilise le menu du navigateur (⋮) puis sélectionne « Ajouter à l’écran d’accueil ».");
+            return;
+          }
+
+          alert("Utilise les options du navigateur pour ajouter cette page à l’écran d’accueil.");
+        });
       });
     })();
   </script>


### PR DESCRIPTION
## Summary
- replace the "Comment faire ?" link in the install banner with a "Télécharger" button that triggers the PWA install flow
- allow the install setup script to manage multiple install triggers so the banner button reuses the same logic as the user menu button
- adjust banner button styling so it behaves correctly as a true button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3cce27f0c833388b060b04b37c77b