### PR TITLE
Supprimer la pastille de catégorie dans l'onglet pratique

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -1960,7 +1960,6 @@ async function renderPractice(ctx, root, _opts = {}) {
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div class="flex flex-wrap items-center gap-2">
             <h4 class="font-semibold">${escapeHtml(c.text)}</h4>
-            ${pill(c.category || "Général")}
             ${prioChip(Number(c.priority)||2)}
             ${srBadge(c)}
           </div>


### PR DESCRIPTION
## Summary
- retire l'affichage de la pastille de catégorie sur les consignes de l'onglet Pratique, déjà filtrées par le sélecteur

## Testing
- not run (non applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3d485d7f0833380700ae75f9c619a