### PR TITLE
Replace notification icon binary with data URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,8 @@
   const BASE_TITLE = "Habitudes & Pratique";
   const ADMIN_ACCESS_KEY = "hp::admin::authorized";
   const ADMIN_LOGIN_PAGE = "admin.html";
+  const DEFAULT_NOTIFICATION_ICON =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAB6ElEQVR42u3d0U0gQAxDwVRGudccRUANJwTrxLNSGvCb/52Pf59frvfGCAAYAgAHgAPAAeAAuHv/8wAoC94KYkTvxjDCd0MY8bsRjPDdEEb8bgQjfDeEEb8bwYjfjWDE70Yw4ncjGPG7EYz43QhG/G4EAAAgfjOCEb8bAQAAiN+MYMTvRgAAAOI3IwAAAPGbEQAAgPjNCAAAQPxmBAAAAAAA4tciAAAA8ZsRAAAAAAAAAID4nQgAAAAAAAAAQPxOBAAAAAAAAAAAAAAAACB+GwIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiWxwcAAAAAAAAAAAAAAAAI2uIDAAAAAAAAAASd8QEAAAAAAAAAgs74AADg17Dm+AAAAAAA/g6ujQ8AAO8AQPA+PgAAvAUAwdv4AADwHkA7gtfbAwDAewCtCBJ2jwHQhiBlcwAAyAHQgiBp7zgA1xGkbQ0AAHkAriJI3DkWwDUEqRtHA7iCIHnfeADbEaRvuwLAVgQbdl0DYBuCLZuuArAFwaY91wFIhrBxx7UA0hBs3XA1gAQI27c7AeAVggu7nQHwlxAu7XUOwG9huLrRaQA/xdCwCwAAAAAAAAAAAAAAAADQBuAb8crY5qD79QEAAAAASUVORK5CYII=";
 
   function getAdminStorage() {
     try {
@@ -283,7 +285,7 @@
 
           const notificationInstance = new Notification(title, {
             body,
-            icon: data.icon || "/icon.png",
+            icon: data.icon || DEFAULT_NOTIFICATION_ICON,
             badge: data.badge || "/badge.png",
             data: { link },
           });

--- a/functions/index.js
+++ b/functions/index.js
@@ -17,7 +17,8 @@ const DAY_NORMALIZE = {
 };
 
 const DAILY_BASE = "https://vincladef.github.io/code-tracking-prod/";
-const ICON_URL = "https://vincladef.github.io/code-tracking-prod/icon.png";
+const ICON_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAB6ElEQVR42u3d0U0gQAxDwVRGudccRUANJwTrxLNSGvCb/52Pf59frvfGCAAYAgAHgAPAAeAAuHv/8wAoC94KYkTvxjDCd0MY8bsRjPDdEEb8bgQjfDeEEb8bwYjfjWDE70Yw4ncjGPG7EYz43QhG/G4EAAAgfjOCEb8bAQAAiN+MYMTvRgAAAOI3IwAAAPGbEQAAgPjNCAAAQPxmBAAAAAAA4tciAAAA8ZsRAAAAAAAAAID4nQgAAAAAAAAAQPxOBAAAAAAAAAAAAAAAACB+GwIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiWxwcAAAAAAAAAAAAAAAAI2uIDAAAAAAAAAASd8QEAAAAAAAAAgs74AADg17Dm+AAAAAAA/g6ujQ8AAO8AQPA+PgAAvAUAwdv4AADwHkA7gtfbAwDAewCtCBJ2jwHQhiBlcwAAyAHQgiBp7zgA1xGkbQ0AAHkAriJI3DkWwDUEqRtHA7iCIHnfeADbEaRvuwLAVgQbdl0DYBuCLZuuArAFwaY91wFIhrBxx7UA0hBs3XA1gAQI27c7AeAVggu7nQHwlxAu7XUOwG9huLrRaQA/xdCwCwAAAAAAAAAAAAAAAADQBuAb8crY5qD79QEAAAAASUVORK5CYII=";
 const BADGE_URL = "https://vincladef.github.io/code-tracking-prod/badge.png";
 
 const INVALID_TOKEN_ERRORS = new Set([
@@ -184,7 +185,7 @@ async function sendReminder(uid, tokens, visibleCount, context) {
       notification: {
         title,
         body,
-        icon: ICON_URL,
+        icon: ICON_DATA_URL,
         badge: BADGE_URL,
       },
     },

--- a/sw.js
+++ b/sw.js
@@ -2,6 +2,9 @@
 importScripts("https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js");
 importScripts("https://www.gstatic.com/firebasejs/9.6.10/firebase-messaging-compat.js");
 
+const DEFAULT_NOTIFICATION_ICON =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAB6ElEQVR42u3d0U0gQAxDwVRGudccRUANJwTrxLNSGvCb/52Pf59frvfGCAAYAgAHgAPAAeAAuHv/8wAoC94KYkTvxjDCd0MY8bsRjPDdEEb8bgQjfDeEEb8bwYjfjWDE70Yw4ncjGPG7EYz43QhG/G4EAAAgfjOCEb8bAQAAiN+MYMTvRgAAAOI3IwAAAPGbEQAAgPjNCAAAQPxmBAAAAAAA4tciAAAA8ZsRAAAAAAAAAID4nQgAAAAAAAAAQPxOBAAAAAAAAAAAAAAAACB+GwIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiWxwcAAAAAAAAAAAAAAAAI2uIDAAAAAAAAAASd8QEAAAAAAAAAgs74AADg17Dm+AAAAAAA/g6ujQ8AAO8AQPA+PgAAvAUAwdv4AADwHkA7gtfbAwDAewCtCBJ2jwHQhiBlcwAAyAHQgiBp7zgA1xGkbQ0AAHkAriJI3DkWwDUEqRtHA7iCIHnfeADbEaRvuwLAVgQbdl0DYBuCLZuuArAFwaY91wFIhrBxx7UA0hBs3XA1gAQI27c7AeAVggu7nQHwlxAu7XUOwG9huLrRaQA/xdCwCwAAAAAAAAAAAAAAAADQBuAb8crY5qD79QEAAAAASUVORK5CYII=";
+
 firebase.initializeApp({
   apiKey: "AIzaSyAQcvZ9a2j4MHF04RjMHIey0R_iwnjZf4o",
   authDomain: "tracking-d-habitudes.firebaseapp.com",
@@ -45,7 +48,7 @@ messaging.onBackgroundMessage((payload = {}) => {
 
   self.registration.showNotification(title, {
     body,
-    icon: data.icon || "/icon.png",
+    icon: data.icon || DEFAULT_NOTIFICATION_ICON,
     badge: data.badge || "/badge.png",
     data: { link: data.link || "/" },
   });


### PR DESCRIPTION
## Summary
- remove the binary `icon.png` asset that previously provided the notification artwork
- inline a turquoise sprout PNG as a reusable data URL for web foreground/background notifications
- update the Cloud Function push payloads to reuse the same data URL icon so remote notifications keep the branding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3d77796a883338ff614006774d096