### PR TITLE
Allow configuring custom goal reminder dates

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -183,6 +183,19 @@ function theoreticalObjectiveDate(objective) {
   return null;
 }
 
+function customObjectiveReminderDate(objective) {
+  if (!objective) return null;
+  const raw =
+    objective.notifyAt ??
+    objective.notifyDate ??
+    objective.notificationDate ??
+    null;
+  const customDate = toDate(raw);
+  if (!customDate) return null;
+  customDate.setHours(0, 0, 0, 0);
+  return customDate;
+}
+
 async function fetchObjectivesByMonth(uid, monthKey) {
   if (!uid || !monthKey) return [];
   try {
@@ -217,7 +230,7 @@ async function countObjectivesDueToday(uid, context) {
   let count = 0;
   for (const objective of objectives) {
     if (objective.notifyOnTarget === false) continue;
-    const dueDate = theoreticalObjectiveDate(objective);
+    const dueDate = customObjectiveReminderDate(objective) || theoreticalObjectiveDate(objective);
     if (!dueDate) continue;
     const iso = dueDate.toISOString().slice(0, 10);
     if (iso === dueIso) {

--- a/index.html
+++ b/index.html
@@ -430,6 +430,12 @@
     .goal-input{ width:100%; }
     .goal-checkbox{ display:inline-flex; align-items:center; gap:.5rem; font-size:.9rem; color:#0f172a; }
     .goal-checkbox input{ width:1.1rem; height:1.1rem; accent-color:var(--accent-500,#4f46e5); }
+    .goal-reminder{ display:grid; gap:.35rem; margin-left:1.75rem; }
+    .goal-reminder__input{ width:min(220px,100%); }
+    .goal-reminder__label{ font-size:.8rem; color:#64748B; }
+    .goal-hint{ font-size:.75rem; color:var(--muted); }
+    .goal-hint.is-disabled{ opacity:.6; }
+    .goal-input[disabled]{ background:#f8fafc; color:#94a3b8; cursor:not-allowed; }
     .goal-actions{ display:flex; justify-content:flex-end; gap:.5rem; flex-wrap:wrap; }
     .goal-actions [data-delete]{ margin-right:auto; }
     .goal-list{ margin-top:.5rem; padding-left:1.25rem; display:grid; gap:.35rem; list-style:disc; }

--- a/schema.js
+++ b/schema.js
@@ -866,6 +866,9 @@ async function upsertObjective(db, uid, data, objectifId = null) {
   if (data?.notifyOnTarget !== undefined) {
     payload.notifyOnTarget = data.notifyOnTarget !== false;
   }
+  if (data?.notifyAt !== undefined) {
+    payload.notifyAt = data.notifyAt || null;
+  }
 
   await setDoc(ref, payload, { merge: true });
   return ref.id;


### PR DESCRIPTION
## Summary
- allow selecting a custom reminder date when editing an objective while keeping the theoretical due date as the default
- add UI styling for the reminder date picker in the objective modal
- persist the optional reminder date in Firestore and use it when computing due reminders

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3e230b0a08333bfa968f76e168dca