### PR TITLE
Adjust install target and naming for admin

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,13 @@
           const raw = storage.getItem(INSTALL_TARGET_STORAGE_KEY);
           if (!raw || typeof raw !== "string") return null;
           const trimmed = raw.trim();
+          if (!trimmed) return null;
+          if (/^#\/admin(?:\/|\?|$)/.test(trimmed)) {
+            const [rawPath = "", searchPart = ""] = trimmed.split("?");
+            const segments = rawPath.replace(/^#\/+/g, "").split("/");
+            const normalizedHash = `#/${segments.filter(Boolean).join("/") || "admin"}`;
+            return searchPart ? `${normalizedHash}?${searchPart}` : normalizedHash;
+          }
           if (!/^#\/u\//.test(trimmed)) return null;
           const [rawPath = "", searchPart = ""] = trimmed.split("?");
           const segments = rawPath.replace(/^#\/+/g, "").split("/");


### PR DESCRIPTION
## Summary
- allow the stored install target to persist admin routes so the installed app opens the admin view when saved from that page
- prefix install shortcut names with the user/admin label and force the admin route to keep the "Admin" suffix
- ensure the PWA manifest updates reflect the new naming scheme and accept the admin label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f21dffbc8333bf8f730b594d3715