### PR TITLE
Masque les onglets utilisateurs sur la page admin

### DIFF
--- a/app.js
+++ b/app.js
@@ -1401,12 +1401,10 @@
         const encodedUid = encodeURIComponent(uid);
         const link = `${location.origin}${location.pathname}#/u/${encodedUid}/daily`;
         items.push(`
-          <div class="flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white p-3">
-            <div>
-              <div class="font-medium">${safeName}</div>
-              <div class="text-sm text-[var(--muted)]">UID: ${safeUid}</div>
-            </div>
-            <div class="flex flex-wrap items-center justify-end gap-2">
+          <div class="rounded-xl border border-gray-200 bg-white p-3">
+            <div class="font-medium">${safeName}</div>
+            <div class="text-sm text-[var(--muted)]">UID: ${safeUid}</div>
+            <div class="mt-3 flex flex-wrap items-center gap-2">
               <a class="btn btn-ghost text-sm"
                  href="${link}"
                  target="_blank"

--- a/index.html
+++ b/index.html
@@ -125,6 +125,7 @@
     /* Onglets (pills) + état actif coloré */
     .tabs{ display:flex; gap:.5rem; align-items:center; overflow-x:auto; flex-wrap:nowrap; -webkit-overflow-scrolling:touch; }
     .tabs::-webkit-scrollbar{ display:none; }
+    body[data-section="admin"] .tabs .tab:not([data-nav="admin"]){ display:none; }
     .tab{ border:1px solid #E5E7EB; background:#fff; border-radius:999px; padding:.5rem .875rem; font-size:.9rem; display:inline-flex; gap:.5rem; align-items:center; white-space:nowrap; flex:0 0 auto; }
     .tab[aria-current="page"]{ background:var(--accent-50); border-color:var(--accent-400); color:#0B4B66; }
 


### PR DESCRIPTION
## Summary
- masque les onglets Journalier/Pratique/Objectifs lorsque la section admin est active
- réorganise la liste des utilisateurs pour afficher les actions sous le nom

## Testing
- non applicable


------
https://chatgpt.com/codex/tasks/task_e_68d3f57959f88333afd27ecd7ff3bb56