### PR TITLE
Add installed app badge updates for pending tasks

### DIFF
--- a/goals.js
+++ b/goals.js
@@ -283,6 +283,9 @@
             todayIso,
             Number(select.value || 0)
           );
+          if (window.__appBadge && typeof window.__appBadge.refresh === "function") {
+            window.__appBadge.refresh(ctx.user?.uid).catch(() => {});
+          }
           applyTone(select.value);
         } catch (err) {
           goalsLogger.error("goals.quickEntry.error", err);
@@ -474,6 +477,9 @@
 
     const currentMonth = Schema.monthKeyFromDate(new Date());
     await showMonth(currentMonth, "auto");
+    if (window.__appBadge && typeof window.__appBadge.refresh === "function") {
+      window.__appBadge.refresh(ctx.user?.uid).catch(() => {});
+    }
   }
 
   function openGoalForm(ctx, goal = null, initial = {}) {

--- a/index.html
+++ b/index.html
@@ -733,6 +733,9 @@
         deferredPrompt = null;
         showButton({ label: primaryDefaultLabel });
         hideBanner();
+        if (window.__appBadge && typeof window.__appBadge.refresh === "function") {
+          window.__appBadge.refresh().catch(() => {});
+        }
       });
 
       if (isiOS && !isStandalone) {

--- a/modes.js
+++ b/modes.js
@@ -2345,11 +2345,17 @@ async function renderDaily(ctx, root, opts = {}) {
       return;
     }
     await Schema.saveResponses(ctx.db, ctx.user.uid, "daily", answers);
+    if (window.__appBadge && typeof window.__appBadge.refresh === "function") {
+      window.__appBadge.refresh(ctx.user?.uid).catch(() => {});
+    }
     showToast("Journal enregistré");
     renderDaily(ctx, root, { day: currentDay, dateIso: dayKey });
   };
 
   modesLogger.groupEnd();
+  if (window.__appBadge && typeof window.__appBadge.refresh === "function") {
+    window.__appBadge.refresh(ctx.user?.uid).catch(() => {});
+  }
 }
 
 function renderHistory() {}

--- a/schema.js
+++ b/schema.js
@@ -900,6 +900,22 @@ async function saveObjectiveEntry(db, uid, objectifId, dateIso, value) {
   await setDoc(ref, { v: value, at: serverTimestamp() }, { merge: true });
 }
 
+async function getObjectiveEntry(db, uid, objectifId, dateIso) {
+  if (!db || !uid || !objectifId || !dateIso) return null;
+  try {
+    const ref = doc(db, "u", uid, "objectiveEntries", objectifId, "entries", dateIso);
+    const snap = await getDoc(ref);
+    if (!snapshotExists(snap)) {
+      return null;
+    }
+    const data = snap.data() || {};
+    return { id: snap.id, ...data };
+  } catch (error) {
+    console.warn("getObjectiveEntry", error);
+    return null;
+  }
+}
+
 async function loadObjectiveEntriesRange(db, uid, objectifId, _fromIso, _toIso) {
   const colRef = collection(db, "u", uid, "objectiveEntries", objectifId, "entries");
   const snap = await getDocs(colRef);
@@ -959,6 +975,7 @@ Object.assign(Schema, {
   deleteObjective,
   linkConsigneToObjective,
   saveObjectiveEntry,
+  getObjectiveEntry,
   loadObjectiveEntriesRange,
 });
 


### PR DESCRIPTION
## Summary
- add a badge manager that computes pending daily items and due objectives and updates the PWA app badge when running in standalone mode
- expose a Schema.getObjectiveEntry helper and call the badge refresh when daily responses or goal entries are saved so the badge clears once tasks are done
- refresh the badge after the PWA is installed and on key renders so installed shortcuts always show the latest pending count

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3fc7b4d8883338bdaba565a96d47d