### PR TITLE
Implement background autosave for forms

### DIFF
--- a/app.js
+++ b/app.js
@@ -1656,7 +1656,7 @@
     root.innerHTML = `
       <div class="space-y-4">
         <h2 class="text-xl font-semibold">Admin — Utilisateurs</h2>
-        <form id="new-user-form" class="card p-4 space-y-3 max-w-md">
+        <form id="new-user-form" class="card p-4 space-y-3 max-w-md" data-autosave-key="admin:new-user">
           <input type="text" id="new-user-name" placeholder="Nom de l’utilisateur" required class="w-full" />
           <button class="btn btn-primary" type="submit">Créer l’utilisateur</button>
         </form>

--- a/autosave.js
+++ b/autosave.js
@@ -1,0 +1,483 @@
+(() => {
+  const STORAGE_PREFIX = "hp::autosave::";
+  const SAVE_DEBOUNCE_MS = 800;
+  const trackedForms = new WeakMap();
+  let formCounter = 0;
+
+  function getStorage() {
+    try {
+      return window.localStorage;
+    } catch (error) {
+      console.warn("[autosave] localStorage inaccessible", error);
+      return null;
+    }
+  }
+
+  const storage = getStorage();
+  const api = {
+    clear(target) {
+      if (!storage) return;
+      if (typeof target === "string") {
+        try {
+          storage.removeItem(target);
+        } catch (error) {
+          console.warn("[autosave] clear:key", error);
+        }
+        return;
+      }
+      if (!target) return;
+      const form = target instanceof HTMLFormElement ? target : null;
+      if (!form) return;
+      const state = trackedForms.get(form);
+      if (!state) return;
+      if (typeof state.scheduleSave?.cancel === "function") {
+        state.scheduleSave.cancel();
+      }
+      try {
+        storage.removeItem(state.key);
+      } catch (error) {
+        console.warn("[autosave] clear:form", error);
+      }
+    },
+  };
+
+  window.formAutosave = Object.assign(window.formAutosave || {}, api);
+
+  if (!storage) {
+    return;
+  }
+
+  function debounce(fn, delay) {
+    let timeoutId = null;
+    function debounced(...args) {
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+      timeoutId = window.setTimeout(() => {
+        timeoutId = null;
+        fn.apply(this, args);
+      }, delay);
+    }
+    debounced.cancel = () => {
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+    return debounced;
+  }
+
+  function shouldIgnoreForm(form) {
+    if (!form || !(form instanceof HTMLFormElement)) return true;
+    const attr = (form.getAttribute("data-autosave") || "").toLowerCase();
+    if (attr === "off" || attr === "false") return true;
+    return false;
+  }
+
+  const IGNORED_INPUT_TYPES = new Set(["button", "submit", "reset", "image", "file", "password", "hidden"]);
+
+  function shouldTrackField(field) {
+    if (!field) return false;
+    if (!("form" in field)) return false;
+    if (field.disabled) return false;
+    if (typeof field.matches === "function" && field.matches("[data-autosave=\"off\"]")) return false;
+    if (field.closest && field.closest("[data-autosave=\"off\"]")) return false;
+    const tag = field.tagName;
+    if (tag === "FIELDSET" || tag === "OBJECT") return false;
+    if (tag === "BUTTON") return false;
+    const type = (field.type || "").toLowerCase();
+    if (IGNORED_INPUT_TYPES.has(type)) return false;
+    return true;
+  }
+
+  function fieldIdentifier(field) {
+    if (!field) return null;
+    const explicit = field.getAttribute("data-autosave-field") || field.getAttribute("data-autosave-key");
+    if (explicit) return explicit;
+    if (field.name) return field.name;
+    if (field.id) return `#${field.id}`;
+    return null;
+  }
+
+  function buildFieldGroups(form) {
+    const groups = new Map();
+    const elements = Array.from(form.elements || []);
+    elements.forEach((element) => {
+      if (!shouldTrackField(element)) return;
+      const key = fieldIdentifier(element);
+      if (!key) return;
+      const normalized = String(key);
+      if (!groups.has(normalized)) {
+        groups.set(normalized, []);
+      }
+      groups.get(normalized).push(element);
+    });
+    return groups;
+  }
+
+  function arraysEqual(a, b) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+
+  function checkedValues(elements, useDefault = false) {
+    const values = [];
+    elements.forEach((el) => {
+      const isChecked = useDefault ? el.defaultChecked : el.checked;
+      if (!isChecked) return;
+      const value = el.value != null ? String(el.value) : "on";
+      values.push(value);
+    });
+    values.sort();
+    return values;
+  }
+
+  function selectValues(select, useDefault = false) {
+    const values = [];
+    const options = Array.from(select.options || []);
+    options.forEach((opt) => {
+      const selected = useDefault ? opt.defaultSelected : opt.selected;
+      if (selected) {
+        values.push(opt.value);
+      }
+    });
+    values.sort();
+    return values;
+  }
+
+  function serializeGroup(elements) {
+    if (!elements || !elements.length) return null;
+    const first = elements[0];
+    if (!first) return null;
+    const type = (first.type || "").toLowerCase();
+    if (type === "radio") {
+      const selected = elements.find((el) => el.checked) || null;
+      const currentValue = selected ? selected.value : null;
+      const defaultSelected = elements.find((el) => el.defaultChecked) || null;
+      const defaultValue = defaultSelected ? defaultSelected.value : null;
+      if (currentValue === defaultValue) return null;
+      return { type: "radio", value: currentValue };
+    }
+    if (type === "checkbox") {
+      if (elements.length > 1) {
+        const currentValues = checkedValues(elements, false);
+        const defaultValues = checkedValues(elements, true);
+        if (arraysEqual(currentValues, defaultValues)) return null;
+        return { type: "checkbox-group", value: currentValues };
+      }
+      const element = first;
+      if (element.checked === element.defaultChecked) return null;
+      return { type: "checkbox", value: Boolean(element.checked) };
+    }
+    if (first instanceof HTMLSelectElement) {
+      if (first.multiple) {
+        const currentValues = selectValues(first, false);
+        const defaultValues = selectValues(first, true);
+        if (arraysEqual(currentValues, defaultValues)) return null;
+        return { type: "select-multiple", value: currentValues };
+      }
+      const currentValue = first.value;
+      const defaultValue = first.defaultValue;
+      if (currentValue === defaultValue) return null;
+      return { type: "value", value: currentValue };
+    }
+    const currentValue = first.value;
+    const defaultValue = first.defaultValue;
+    if (currentValue === defaultValue) return null;
+    return { type: "value", value: currentValue };
+  }
+
+  function serializeForm(form) {
+    const groups = buildFieldGroups(form);
+    const fields = {};
+    groups.forEach((elements, key) => {
+      const entry = serializeGroup(elements);
+      if (entry) {
+        fields[key] = entry;
+      }
+    });
+    if (!Object.keys(fields).length) {
+      return null;
+    }
+    return { version: 1, fields };
+  }
+
+  function dispatchUpdateEvents(element) {
+    if (!element) return;
+    const eventInit = { bubbles: true };
+    try {
+      element.dispatchEvent(new Event("input", eventInit));
+    } catch (error) {
+      const evt = document.createEvent("Event");
+      evt.initEvent("input", true, true);
+      element.dispatchEvent(evt);
+    }
+    try {
+      element.dispatchEvent(new Event("change", eventInit));
+    } catch (error) {
+      const evt = document.createEvent("Event");
+      evt.initEvent("change", true, true);
+      element.dispatchEvent(evt);
+    }
+  }
+
+  function applyEntry(elements, entry) {
+    if (!entry || !elements || !elements.length) return;
+    const type = entry.type;
+    if (type === "checkbox") {
+      const element = elements[0];
+      if (!element) return;
+      const desired = entry.value === true;
+      if (element.checked !== desired) {
+        element.checked = desired;
+        dispatchUpdateEvents(element);
+      }
+      return;
+    }
+    if (type === "checkbox-group") {
+      const values = Array.isArray(entry.value) ? entry.value.map((v) => String(v)) : [];
+      const valueSet = new Set(values);
+      elements.forEach((element) => {
+        const optionValue = element.value != null ? String(element.value) : "on";
+        const shouldCheck = valueSet.has(optionValue);
+        if (element.checked !== shouldCheck) {
+          element.checked = shouldCheck;
+          dispatchUpdateEvents(element);
+        }
+      });
+      return;
+    }
+    if (type === "radio") {
+      const desiredValue = entry.value != null ? String(entry.value) : null;
+      elements.forEach((element) => {
+        const shouldCheck = desiredValue != null && String(element.value) === desiredValue;
+        if (element.checked !== shouldCheck) {
+          element.checked = shouldCheck;
+          dispatchUpdateEvents(element);
+        }
+      });
+      if (desiredValue == null) {
+        elements.forEach((element) => {
+          if (element.checked) {
+            element.checked = false;
+            dispatchUpdateEvents(element);
+          }
+        });
+      }
+      return;
+    }
+    const element = elements[0];
+    if (!element) return;
+    if (type === "select-multiple" && element instanceof HTMLSelectElement) {
+      const values = Array.isArray(entry.value) ? entry.value.map((v) => String(v)) : [];
+      const valueSet = new Set(values);
+      let changed = false;
+      Array.from(element.options || []).forEach((option) => {
+        const shouldSelect = valueSet.has(option.value);
+        if (option.selected !== shouldSelect) {
+          option.selected = shouldSelect;
+          changed = true;
+        }
+      });
+      if (changed) {
+        dispatchUpdateEvents(element);
+      }
+      return;
+    }
+    const nextValue = entry.value != null ? String(entry.value) : "";
+    if (element.value !== nextValue) {
+      element.value = nextValue;
+      dispatchUpdateEvents(element);
+    }
+  }
+
+  function loadState(key) {
+    if (!key) return null;
+    try {
+      const raw = storage.getItem(key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") return null;
+      return parsed;
+    } catch (error) {
+      console.warn("[autosave] read", error);
+      return null;
+    }
+  }
+
+  function persistState(key, state) {
+    if (!key) return;
+    if (!state) {
+      try {
+        storage.removeItem(key);
+      } catch (error) {
+        console.warn("[autosave] remove", error);
+      }
+      return;
+    }
+    try {
+      storage.setItem(key, JSON.stringify(state));
+    } catch (error) {
+      console.warn("[autosave] write", error);
+    }
+  }
+
+  function locationScope() {
+    const path = window.location?.pathname || "";
+    const hash = window.location?.hash || "";
+    return `${path}::${hash}`;
+  }
+
+  function computeAnonymousId(form) {
+    if (!form.__autosaveAnonId) {
+      form.__autosaveAnonId = `form-${Date.now().toString(36)}-${(formCounter += 1).toString(36)}`;
+    }
+    return form.__autosaveAnonId;
+  }
+
+  function computeFormKey(form) {
+    const scope = locationScope();
+    const explicit = form.getAttribute("data-autosave-key");
+    const keyParts = [scope];
+    if (explicit) {
+      keyParts.push(explicit);
+      return `${STORAGE_PREFIX}${keyParts.join("::")}`;
+    }
+    if (form.id) keyParts.push(`#${form.id}`);
+    const nameAttr = form.getAttribute("name");
+    if (nameAttr) keyParts.push(`name=${nameAttr}`);
+    const action = form.getAttribute("action");
+    if (action) keyParts.push(`action=${action}`);
+    const classes = (form.className || "").trim();
+    if (classes) {
+      keyParts.push(`classes=${classes.split(/\s+/).slice(0, 3).join(".")}`);
+    }
+    const fieldGroups = buildFieldGroups(form);
+    if (fieldGroups.size) {
+      const fieldNames = Array.from(fieldGroups.keys()).sort();
+      keyParts.push(`fields=${fieldNames.join("|")}`);
+    }
+    if (keyParts.length === 1) {
+      keyParts.push(computeAnonymousId(form));
+    }
+    return `${STORAGE_PREFIX}${keyParts.join("::")}`;
+  }
+
+  function restoreForm(form, state, stored) {
+    if (!stored || typeof stored !== "object") return;
+    const fields = stored.fields;
+    if (!fields || typeof fields !== "object") return;
+    state.restoring = true;
+    try {
+      const groups = buildFieldGroups(form);
+      Object.keys(fields).forEach((key) => {
+        const elements = groups.get(key);
+        if (!elements) return;
+        applyEntry(elements, fields[key]);
+      });
+    } finally {
+      window.setTimeout(() => {
+        state.restoring = false;
+      }, 0);
+    }
+  }
+
+  function registerForm(form) {
+    if (shouldIgnoreForm(form)) return;
+    if (trackedForms.has(form)) return;
+    const key = computeFormKey(form);
+    if (!key) return;
+    const scheduleSave = debounce(() => {
+      const serialized = serializeForm(form);
+      if (!serialized) {
+        persistState(key, null);
+        return;
+      }
+      persistState(key, serialized);
+    }, SAVE_DEBOUNCE_MS);
+
+    const state = {
+      key,
+      scheduleSave,
+      restoring: false,
+    };
+
+    const handleInput = (event) => {
+      if (event && event.target && event.target.form && event.target.form !== form) return;
+      if (state.restoring) return;
+      scheduleSave();
+    };
+
+    const handleSubmit = () => {
+      if (typeof scheduleSave.cancel === "function") {
+        scheduleSave.cancel();
+      }
+      persistState(state.key, null);
+    };
+
+    form.addEventListener("input", handleInput);
+    form.addEventListener("change", handleInput);
+    form.addEventListener("submit", handleSubmit);
+    form.addEventListener("reset", handleSubmit);
+
+    trackedForms.set(form, state);
+
+    const stored = loadState(key);
+    if (stored) {
+      restoreForm(form, state, stored);
+    }
+  }
+
+  function updateFormKey(form) {
+    const state = trackedForms.get(form);
+    if (!state) {
+      registerForm(form);
+      return;
+    }
+    const nextKey = computeFormKey(form);
+    if (!nextKey || nextKey === state.key) return;
+    try {
+      storage.removeItem(state.key);
+    } catch (error) {
+      console.warn("[autosave] key:update", error);
+    }
+    state.key = nextKey;
+    const stored = loadState(nextKey);
+    if (stored) {
+      restoreForm(form, state, stored);
+    }
+  }
+
+  function handleMutations(mutations) {
+    mutations.forEach((mutation) => {
+      if (mutation.type === "childList") {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof HTMLFormElement) {
+            registerForm(node);
+          } else if (node && typeof node.querySelectorAll === "function") {
+            const forms = node.querySelectorAll("form");
+            forms.forEach((form) => registerForm(form));
+          }
+        });
+      } else if (mutation.type === "attributes" && mutation.attributeName === "data-autosave-key") {
+        const target = mutation.target;
+        if (target instanceof HTMLFormElement) {
+          updateFormKey(target);
+        }
+      }
+    });
+  }
+
+  Array.from(document.forms || []).forEach((form) => registerForm(form));
+
+  const observer = new MutationObserver(handleMutations);
+  observer.observe(document.documentElement || document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["data-autosave-key"],
+  });
+})();

--- a/goals.js
+++ b/goals.js
@@ -516,13 +516,20 @@
 
     const wrap = document.createElement("div");
     wrap.className = "goal-modal";
+    const autosaveKey = [
+      "goal",
+      ctx.user?.uid || "anon",
+      goal?.id ? `edit-${goal.id}` : `new-${monthKey}-${typeInitial}`,
+    ]
+      .map((part) => String(part))
+      .join(":");
     wrap.innerHTML = `
       <div class="goal-modal-card">
         <div class="goal-modal-header">
           <div class="goal-modal-title">${goal ? "Modifier" : "Nouvel"} objectif</div>
           <button class="btn-ghost" type="button" data-close>✕</button>
         </div>
-        <form class="goal-form" id="goal-form">
+        <form class="goal-form" id="goal-form" data-autosave-key="${escapeHtml(autosaveKey)}">
           <div class="goal-field">
             <span class="goal-label">Mois concerné</span>
             <div class="goal-month-pill">${escapeHtml(monthLabel)}</div>

--- a/index.html
+++ b/index.html
@@ -616,6 +616,7 @@
   <script src="schema.js"></script>
   <script src="modes.js"></script>
   <script src="goals.js"></script>
+  <script src="autosave.js"></script>
   <script src="app.js"></script>
   <script>
     (function initApp() {


### PR DESCRIPTION
## Summary
- add a global autosave helper that saves form fields to localStorage and restores them when returning to the page
- wire the autosave script into the app and assign stable data-autosave-key values to admin, practice, consigne and goal forms
- clear stored practice session drafts after saving to avoid stale autosaved data

## Testing
- ⚠️ not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4ea0657e08333b015a6cf3c96ee1e