### PR TITLE
Add scrollable consigne settings modal

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -33,7 +33,7 @@ function modal(html) {
   const wrap = document.createElement("div");
   wrap.className = "fixed inset-0 z-50 grid place-items-center bg-black/40 p-4";
   wrap.innerHTML = `
-    <div class="w-[min(680px,92vw)] rounded-2xl bg-white border border-gray-200 p-6 shadow-2xl">
+    <div class="w-[min(680px,92vw)] max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl bg-white border border-gray-200 p-6 shadow-2xl">
       ${html}
     </div>`;
   wrap.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- limit the height of modals used for consigne management forms and enable vertical scrolling when content exceeds the viewport

## Testing
- no tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d4f489d7cc8333b14eba7b778aed98