### PR TITLE
Add admin push notification controls

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -349,6 +349,29 @@ async function disablePushToken(db, uid, token) {
   }, { merge: true });
 }
 
+async function saveAdminPushToken(db, token, extra = {}) {
+  if (!db || !token) return;
+  const ref = doc(collection(db, "adminPushTokens"), token);
+  await setDoc(ref, {
+    token,
+    enabled: true,
+    ua: navigator.userAgent || "",
+    platform: navigator.platform || "",
+    updatedAt: serverTimestamp(),
+    createdAt: serverTimestamp(),
+    ...extra,
+  }, { merge: true });
+}
+
+async function disableAdminPushToken(db, token) {
+  if (!db || !token) return;
+  const ref = doc(collection(db, "adminPushTokens"), token);
+  await setDoc(ref, {
+    enabled: false,
+    updatedAt: serverTimestamp(),
+  }, { merge: true });
+}
+
 // score pour likert -> 0 / 0.5 / 1
 function likertScore(v) {
   return ({ yes: 1, rather_yes: 0.5, medium: 0, rather_no: 0, no: 0, no_answer: 0 })[v] ?? 0;
@@ -970,6 +993,8 @@ Object.assign(Schema, {
   upsertSRState,
   savePushToken,
   disablePushToken,
+  saveAdminPushToken,
+  disableAdminPushToken,
   likertScore,
   nextCooldownAfterAnswer,
   resetSRForConsigne,


### PR DESCRIPTION
## Summary
- add an admin notifications control card and preference handling in the admin interface
- persist admin push tokens via new schema helpers and reuse the push setup flow
- send admin-targeted copies of daily reminders from the Cloud Function using dedicated tokens

## Testing
- npm --prefix functions install *(fails: 403 Forbidden from registry)*
- npm --prefix functions run lint *(fails: ESLint config missing for v9)*

------
https://chatgpt.com/codex/tasks/task_e_68d504320f408333a0439765e6d24a19