### PR TITLE
Allow manual daily reminder runs outside scheduled hour

### DIFF
--- a/.github/workflows/daily-reminder.yml
+++ b/.github/workflows/daily-reminder.yml
@@ -133,9 +133,15 @@ jobs:
 
           async function main(){
             const ctx = parisContext();
-            if (ctx.hour !== 6){
+            const eventName = process.env.GITHUB_EVENT_NAME;
+            const isManual = eventName === "workflow_dispatch";
+
+            if (ctx.hour !== 6 && !isManual){
               console.log(`skip run: current Paris hour = ${ctx.hour}`);
               return;
+            }
+            if (ctx.hour !== 6 && isManual){
+              console.log(`manual override: event=${eventName}, current Paris hour = ${ctx.hour}`);
             }
             console.log("context", ctx);
             const tokensByUid = await collectTokensByUid();


### PR DESCRIPTION
## Summary
- allow the daily reminder workflow to continue when manually dispatched outside the scheduled hour
- log when a manual run overrides the hour guard for easier debugging

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d53aee527883339dc83342d3469b74