### PR TITLE
Add objective-consigne linking UI and history

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,6 +493,25 @@
     .goal-actions{ display:flex; justify-content:flex-end; gap:.5rem; flex-wrap:wrap; }
     .goal-actions [data-delete]{ margin-right:auto; }
     .goal-list{ margin-top:.5rem; padding-left:1.25rem; display:grid; gap:.35rem; list-style:disc; }
+    .objective-select{ gap:.35rem; }
+    .objective-select__meta{ display:flex; align-items:center; flex-wrap:wrap; gap:.4rem; font-size:.8rem; color:#64748b; }
+    .objective-select__badge{ display:inline-flex; align-items:center; gap:.35rem; padding:.15rem .6rem; border-radius:999px; background:var(--accent-50); border:1px solid var(--accent-200); font-size:.72rem; font-weight:600; color:#4338ca; }
+    .objective-select__period{ font-size:.78rem; color:#475569; }
+    .objective-select__placeholder{ font-size:.75rem; color:#94a3b8; }
+    .goal-linker{ border:1px solid rgba(148,163,184,.35); background:#f8fafc; border-radius:.9rem; padding:.85rem 1rem; display:grid; gap:.75rem; }
+    .goal-linker__controls{ display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; }
+    .goal-linker__summary{ font-size:.85rem; font-weight:500; color:#475569; }
+    .goal-linker__panel{ border:1px dashed rgba(148,163,184,.45); background:#fff; border-radius:.75rem; padding:.6rem .75rem; display:grid; gap:.45rem; max-height:220px; overflow:auto; }
+    .goal-linker__panel[hidden]{ display:none; }
+    .goal-linker__option{ display:grid; grid-template-columns:auto 1fr; align-items:flex-start; gap:.55rem; padding:.35rem .45rem; border-radius:.65rem; transition:background .15s ease, box-shadow .15s ease; }
+    .goal-linker__option:hover{ background:rgba(99,102,241,.08); }
+    .goal-linker__option input{ width:1.05rem; height:1.05rem; margin-top:.2rem; accent-color:var(--accent-500,#4f46e5); }
+    .goal-linker__option-main{ font-weight:600; color:#1f2937; }
+    .goal-linker__option-meta{ grid-column:2/span 1; font-size:.75rem; color:#64748b; }
+    .goal-linker__empty{ margin:0; font-size:.85rem; color:#64748b; }
+    .goal-linker__footer{ display:flex; justify-content:flex-end; }
+    .goal-linker__toggle[disabled]{ opacity:.5; cursor:not-allowed; }
+    .goal-linker__history[hidden]{ display:none; }
 
     .practice-dashboard__card{ width:min(1040px,96vw); max-height:92vh; display:flex; flex-direction:column; gap:1.25rem; padding:1.5rem 1.75rem; overflow:hidden; }
     .practice-dashboard__header{ display:flex; align-items:center; justify-content:space-between; gap:.75rem; }

--- a/schema.js
+++ b/schema.js
@@ -945,6 +945,16 @@ async function linkConsigneToObjective(db, uid, consigneId, objectifId) {
   );
 }
 
+async function listConsignesByObjective(db, uid, objectifId) {
+  if (!objectifId) return [];
+  const qy = query(
+    col(db, uid, "consignes"),
+    where("objectiveId", "==", objectifId)
+  );
+  const snap = await getDocs(qy);
+  return snap.docs.map((docSnap) => hydrateConsigne(docSnap));
+}
+
 async function saveObjectiveEntry(db, uid, objectifId, dateIso, value) {
   const ref = doc(db, "u", uid, "objectiveEntries", objectifId, "entries", dateIso);
   await setDoc(ref, { v: value, at: serverTimestamp() }, { merge: true });
@@ -1027,6 +1037,7 @@ Object.assign(Schema, {
   upsertObjective,
   deleteObjective,
   linkConsigneToObjective,
+  listConsignesByObjective,
   saveObjectiveEntry,
   getObjectiveEntry,
   loadObjectiveEntriesRange,


### PR DESCRIPTION
## Summary
- simplify the consigne form objective selector by showing only titles with contextual badges
- allow objectives to manage linked consignes from the goal modal, including history access
- extend the practice dashboard to support filtered views for objective-linked consignes

## Testing
- not run (static changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d55309dcdc8333b80b5d25183611b1