### PR TITLE
Improve practice dashboard visuals and mobile UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,15 +518,22 @@
     .practice-dashboard{ --dashboard-surface:var(--card-bg); --dashboard-border:rgba(148,163,184,.28); --dashboard-shadow:0 28px 48px rgba(15,23,42,.12); --dashboard-header-bg:#F8FAFC; --dashboard-grid-stripe:rgba(241,245,249,.45); --dashboard-chip-bg:rgba(148,163,184,.12); --dashboard-status-ok:rgba(34,197,94,.16); --dashboard-status-ok-text:#166534; --dashboard-status-mid:rgba(250,204,21,.18); --dashboard-status-mid-text:#92400E; --dashboard-status-ko:rgba(248,113,113,.22); --dashboard-status-ko-text:#991B1B; --dashboard-status-na:#F8FAFC; --dashboard-status-na-text:#94A3B8; }
     .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(.75rem,2vw,1.5rem); }
     .practice-dashboard.goal-modal .modal-card{ padding:0; background:transparent; box-shadow:none; border:0; }
-    .practice-dashboard__card{ width:min(1080px,calc(100vw - 2rem)); max-height:min(94vh,820px); display:flex; flex-direction:column; gap:1.5rem; padding:1.75rem clamp(1.25rem,3vw,2.25rem); overflow:hidden; background:var(--dashboard-surface); border:1px solid var(--dashboard-border); border-radius:1.25rem; box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__header{ display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:1rem; }
+    .practice-dashboard__card{ position:relative; width:min(1080px,calc(100vw - 2rem)); max-height:min(94vh,820px); display:flex; flex-direction:column; gap:1.6rem; padding:1.9rem clamp(1.4rem,3vw,2.4rem); background:var(--dashboard-surface); border:1px solid var(--dashboard-border); border-radius:1.5rem; box-shadow:var(--dashboard-shadow); overflow:hidden; isolation:isolate; }
+    .practice-dashboard__card::before{ content:""; position:absolute; inset:-40% -32% auto -28%; height:72%; background:radial-gradient(circle at top left, var(--accent-50) 0%, rgba(255,255,255,0) 68%); pointer-events:none; z-index:0; }
+    .practice-dashboard__card > *{ position:relative; z-index:1; }
+    .practice-dashboard__header{ position:relative; display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:1rem; padding-bottom:1rem; }
+    .practice-dashboard__header::after{ content:""; position:absolute; left:0; right:0; bottom:0; height:1px; background:linear-gradient(90deg, rgba(148,163,184,.12) 0%, rgba(148,163,184,.4) 38%, rgba(148,163,184,.1) 100%); }
     .practice-dashboard__title{ font-size:1.25rem; font-weight:700; color:#0f172a; letter-spacing:-.01em; }
-    .practice-dashboard__header-actions{ display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; justify-content:flex-end; }
+    .practice-dashboard__header-actions{ display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; justify-content:flex-end; padding-top:.25rem; }
+    .practice-dashboard__close{ border-color:transparent; background:rgba(148,163,184,.16); color:#0f172a; transition:background .15s ease, transform .15s ease; }
+    .practice-dashboard__close:hover{ background:rgba(148,163,184,.26); transform:translateY(-1px); }
+    .practice-dashboard__close:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__body{ flex:1 1 auto; overflow-y:auto; padding-right:.25rem; margin-right:-.25rem; display:flex; flex-direction:column; gap:1.5rem; }
     .practice-dashboard__section{ display:flex; flex-direction:column; gap:1rem; }
     .practice-dashboard__section-head{ display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; }
     .practice-dashboard__section-title{ font-weight:600; font-size:1rem; color:#0f172a; letter-spacing:-.01em; }
-    .practice-dashboard__table-wrapper{ border:1px solid var(--dashboard-border); border-radius:1rem; overflow:auto; background:var(--dashboard-surface); box-shadow:0 18px 32px rgba(15,23,42,.08); }
+    .practice-dashboard__table-wrapper{ position:relative; border:1px solid var(--dashboard-border); border-radius:1.1rem; overflow:auto; background:linear-gradient(180deg, rgba(255,255,255,.98) 0%, rgba(248,250,252,.98) 100%); box-shadow:0 20px 38px rgba(15,23,42,.1); }
+    .practice-dashboard__table-wrapper::after{ content:""; position:absolute; top:0; right:0; bottom:0; width:2.5rem; pointer-events:none; background:linear-gradient(90deg, rgba(248,250,252,0) 0%, rgba(248,250,252,.92) 65%, rgba(248,250,252,1) 100%); }
     .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:8px; }
     .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:#CBD5F5; border-radius:999px; }
     .practice-dashboard__matrix{ width:100%; border-collapse:separate; border-spacing:0; min-width:660px; }
@@ -562,7 +569,7 @@
     .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
     .practice-dashboard__matrix tbody td{ padding:.45rem .35rem; text-align:center; }
     .practice-dashboard__matrix tbody tr:nth-child(even){ background:var(--dashboard-grid-stripe); }
-    .practice-dashboard__cell{ position:relative; width:100%; min-width:3.5rem; padding:.55rem .35rem; border-radius:.75rem; border:1px solid transparent; font-weight:600; font-size:.85rem; background:#F8FAFC; color:#0f172a; display:flex; align-items:center; justify-content:center; transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease; }
+    .practice-dashboard__cell{ position:relative; width:100%; min-width:3.5rem; padding:.55rem .35rem; border-radius:.75rem; border:1px solid transparent; font-weight:600; font-size:.85rem; background:#F8FAFC; color:#0f172a; display:flex; align-items:center; justify-content:center; transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease; font-variant-numeric:tabular-nums; line-height:1.35; }
     .practice-dashboard__cell--ok{ background:var(--dashboard-status-ok); color:var(--dashboard-status-ok-text); }
     .practice-dashboard__cell--mid{ background:var(--dashboard-status-mid); color:var(--dashboard-status-mid-text); }
     .practice-dashboard__cell--ko{ background:var(--dashboard-status-ko); color:var(--dashboard-status-ko-text); }
@@ -572,14 +579,15 @@
     .practice-dashboard__cell:hover{ transform:translateY(-1px); box-shadow:0 6px 14px rgba(15,23,42,.12); border-color:rgba(148,163,184,.35); }
     .practice-dashboard__cell:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__hint{ font-size:.8rem; color:#64748B; text-align:right; }
-    .practice-dashboard__chart-panel{ display:flex; flex-direction:column; gap:.65rem; }
+    .practice-dashboard__chart-panel{ display:flex; flex-direction:column; gap:.85rem; }
     .practice-dashboard__chart-scroll{ border-radius:1rem; overflow-x:auto; padding-bottom:.25rem; margin-bottom:-.25rem; cursor:grab; -webkit-overflow-scrolling:touch; touch-action:pan-y; scroll-snap-type:x proximity; }
     .practice-dashboard__chart-scroll:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__chart-scroll.is-dragging{ cursor:grabbing; user-select:none; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar{ height:10px; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar-track{ background:transparent; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar-thumb{ background:#CBD5F5; border-radius:999px; }
-    .practice-dashboard__chart-card{ border:1px solid var(--dashboard-border); border-radius:1rem; background:var(--dashboard-surface); padding:1rem 1.25rem; min-height:280px; box-shadow:0 18px 32px rgba(15,23,42,.08); position:relative; }
+    .practice-dashboard__chart-card{ position:relative; border:1px solid var(--dashboard-border); border-radius:1.1rem; background:linear-gradient(180deg, rgba(255,255,255,.98) 0%, rgba(241,245,249,.95) 100%); padding:1.15rem 1.5rem 1.35rem; min-height:300px; box-shadow:0 22px 42px rgba(15,23,42,.1); }
+    .practice-dashboard__chart-card::before{ content:""; position:absolute; inset:0; border-radius:inherit; box-shadow:inset 0 1px 0 rgba(255,255,255,.6); pointer-events:none; }
     .practice-dashboard__chart-canvas{ position:relative; min-height:280px; min-width:520px; }
     .practice-dashboard__chart-card canvas{ width:100%; height:100%; }
     .practice-dashboard__chart-caption{ font-size:.85rem; color:#64748B; }
@@ -603,31 +611,56 @@
     .practice-dashboard__chart-empty{ font-size:.85rem; color:#94A3B8; }
     .practice-dashboard__empty{ padding:1.25rem; border-radius:1rem; border:1px dashed #CBD5F5; background:#F8FAFC; font-size:.9rem; color:#64748B; text-align:center; }
     .practice-dashboard__empty-row{ padding:2rem 1rem; text-align:center; font-size:.9rem; color:#94A3B8; }
+    @media (min-width: 1024px){
+      .practice-dashboard__body{ display:grid; grid-template-columns:minmax(0,0.95fr) minmax(0,1fr); gap:2.25rem; align-items:flex-start; }
+      .practice-dashboard__section--chart{ position:sticky; top:1.25rem; align-self:flex-start; }
+    }
     @media (max-width: 1024px){
       .practice-dashboard__card{ width:min(100%,calc(100vw - 1.5rem)); }
     }
     @media (max-width: 768px){
       .practice-dashboard.goal-modal{ padding:0; align-items:stretch; }
-      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:none; border:0; padding:1.5rem 1.25rem; }
-      .practice-dashboard__body{ padding-right:0; margin-right:0; gap:1.25rem; }
-      .practice-dashboard__header{ flex-direction:column; align-items:flex-start; gap:.75rem; }
-      .practice-dashboard__header-actions{ width:100%; flex-direction:column; align-items:stretch; gap:.5rem; justify-content:flex-start; }
+      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:none; border:0; padding:1.35rem clamp(1rem,4vw,1.5rem) 1.6rem; }
+      .practice-dashboard.goal-modal .practice-dashboard__card{ padding-top:calc(env(safe-area-inset-top,0) + 1.35rem); }
+      .practice-dashboard__card::before{ inset:-52% -44% auto -40%; }
+      .practice-dashboard__body{ padding-right:0; margin-right:0; gap:1.35rem; }
+      .practice-dashboard__header{ flex-direction:column; align-items:flex-start; gap:.85rem; padding-bottom:.85rem; }
+      .practice-dashboard__header::after{ left:-.5rem; right:-.5rem; }
+      .practice-dashboard__header-actions{ width:100%; flex-direction:column; align-items:stretch; gap:.6rem; justify-content:flex-start; padding-top:0; }
       .practice-dashboard__view-toggle{ width:100%; justify-content:space-between; }
       .practice-dashboard__view-btn{ flex:1 1 auto; text-align:center; }
       .practice-dashboard__filter-select{ width:100%; }
       .practice-dashboard__chart-panel{ gap:.75rem; }
-      .practice-dashboard__chart-card{ min-height:220px; }
+      .practice-dashboard__chart-card{ min-height:240px; padding:1rem 1.15rem 1.2rem; }
       .practice-dashboard__chart-canvas{ min-width:min(520px,100%); }
       .practice-dashboard__chart-zoom,
-      .practice-dashboard__chart-controls{ flex-direction:column; align-items:stretch; gap:.4rem; }
+      .practice-dashboard__chart-controls{ flex-direction:column; align-items:stretch; gap:.45rem; }
       .practice-dashboard__chart-option{ justify-content:space-between; }
-      .practice-dashboard__table-wrapper{ box-shadow:0 14px 24px rgba(15,23,42,.08); }
+      .practice-dashboard__table-wrapper{ box-shadow:0 16px 28px rgba(15,23,42,.1); }
       .practice-dashboard__hint{ text-align:left; }
     }
-    @media (max-width: 540px){
-      .practice-dashboard__matrix{ min-width:520px; }
-      .practice-dashboard__title{ font-size:1.15rem; }
+    @media (max-width: 640px){
+      .practice-dashboard__title{ font-size:1.12rem; }
       .practice-dashboard__section-title{ font-size:.95rem; }
+      .practice-dashboard__table-wrapper{ padding:0; background:transparent; border:0; box-shadow:none; overflow:visible; }
+      .practice-dashboard__table-wrapper::after{ display:none; }
+      .practice-dashboard__matrix{ width:100%; min-width:0; border-collapse:separate; border-spacing:0; }
+      .practice-dashboard__matrix thead{ display:none; }
+      .practice-dashboard__matrix tbody{ display:flex; flex-direction:column; gap:1rem; }
+      .practice-dashboard__matrix tbody tr{ position:relative; display:flex; flex-direction:column; gap:.75rem; padding:1rem clamp(.75rem,4vw,1.25rem); border-radius:1.15rem; background:linear-gradient(180deg,#ffffff 0%,#f8fafc 100%); box-shadow:0 14px 30px rgba(15,23,42,.12); border:1px solid rgba(226,232,240,.6); }
+      .practice-dashboard__matrix tbody td{ padding:0; text-align:left; }
+      .practice-dashboard__matrix-consigne{ position:static; left:auto; background:transparent; padding:0; border-right:0; box-shadow:none; }
+      .practice-dashboard__row-head{ gap:.65rem; align-items:flex-start; }
+      .practice-dashboard__row-indicator{ height:1.75rem; }
+      .practice-dashboard__row-info{ gap:.2rem; }
+      .practice-dashboard__matrix tbody tr::after{ content:""; position:absolute; inset:0; border-radius:inherit; pointer-events:none; opacity:.12; background:linear-gradient(135deg,var(--accent-50) 0%,transparent 70%); z-index:0; }
+      .practice-dashboard__matrix tbody tr > *{ position:relative; z-index:1; }
+      .practice-dashboard__matrix tbody tr:nth-child(even)::after{ background:linear-gradient(135deg,var(--accent-200) 0%,transparent 70%); }
+      .practice-dashboard__cell{ width:100%; min-width:0; padding:.65rem .75rem; justify-content:flex-start; align-items:flex-start; gap:.35rem; text-align:left; font-size:.92rem; }
+      .practice-dashboard__cell::before{ content:attr(data-label); font-size:.7rem; font-weight:600; letter-spacing:.08em; text-transform:uppercase; color:#64748B; }
+      .practice-dashboard__cell[data-has-note="1"]::after{ top:8px; right:8px; }
+      .practice-dashboard__cell:hover{ transform:none; box-shadow:0 8px 18px rgba(15,23,42,.12); }
+      .practice-dashboard__hint{ margin-top:-.25rem; }
     }
 
     .practice-editor{ display:flex; flex-direction:column; gap:1rem; }

--- a/modes.js
+++ b/modes.js
@@ -1061,7 +1061,8 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
         '<th scope="col" class="practice-dashboard__matrix-head-consigne">Consigne</th>',
         ...iterationDisplayMeta.map((meta) => {
           const title = meta.headerTitle || meta.label;
-          return `<th scope="col" data-date="${meta.iso}" data-iteration="${meta.index}"><span title="${escapeHtml(title)}">${escapeHtml(meta.label)}</span></th>`;
+          const columnLabel = meta.label || title || "";
+          return `<th scope="col" data-date="${meta.iso}" data-iteration="${meta.index}" data-label="${escapeHtml(columnLabel)}"><span title="${escapeHtml(title)}">${escapeHtml(meta.label)}</span></th>`;
         }),
       ].join("");
     }
@@ -1338,7 +1339,11 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
               ]
                 .filter(Boolean)
                 .join(" ");
-              return `<td><button type="button" class="${classes}" data-cell data-consigne="${stat.id}" data-date="${dateIso}" data-iteration="${iterationInfo.index}" title="${escapeHtml(tooltip)}" aria-label="${escapeHtml(tooltip)}"${hasNote}>${content}</button></td>`;
+              const compactLabel = iterationInfo.label || iterationInfo.fullLabel || iterationInfo.headerTitle || `Itération ${iterationInfo.displayIndex}`;
+              const verboseLabel = iterationInfo.headerTitle || iterationInfo.fullLabel || compactLabel;
+              const labelAttr = ` data-label="${escapeHtml(compactLabel)}"`;
+              const labelFullAttr = verboseLabel && verboseLabel !== compactLabel ? ` data-label-full="${escapeHtml(verboseLabel)}"` : "";
+              return `<td data-column="${escapeHtml(iterationInfo.iso)}"><button type="button" class="${classes}" data-cell data-consigne="${stat.id}" data-date="${dateIso}" data-iteration="${iterationInfo.index}" title="${escapeHtml(tooltip)}" aria-label="${escapeHtml(tooltip)}"${hasNote}${labelAttr}${labelFullAttr}>${content}</button></td>`;
             })
             .join("");
           return `<tr data-id="${stat.id}">${rowHead}${cells}</tr>`;


### PR DESCRIPTION
## Summary
- refresh the practice dashboard card, header and chart styling with softer gradients, layering and a sticky desktop layout
- redesign the practice matrix for small screens and expose column labels through data attributes for mobile readability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d588d65940833391f57f746e047215