### PR TITLE
Simplify practice dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,33 +525,32 @@
 
     .practice-dashboard{
       --dashboard-surface:#ffffff;
-      --dashboard-border:#CBD5F5;
-      --dashboard-shadow:none;
-      --dashboard-header-bg:#E2E8F0;
-      --dashboard-grid-stripe:#F1F5F9;
-      --dashboard-chip-bg:#E2E8F0;
-      --dashboard-status-ok:#BBF7D0;
-      --dashboard-status-ok-text:#166534;
-      --dashboard-status-mid:#FDE68A;
-      --dashboard-status-mid-text:#92400E;
-      --dashboard-status-ko:#FCA5A5;
-      --dashboard-status-ko-text:#991B1B;
-      --dashboard-status-na:#E2E8F0;
+      --dashboard-border:rgba(15,23,42,0.08);
+      --dashboard-shadow:0 22px 48px rgba(15,23,42,0.12);
+      --dashboard-header-bg:#f8fafc;
+      --dashboard-grid-stripe:rgba(148,163,184,0.08);
+      --dashboard-status-ok:rgba(16,185,129,0.12);
+      --dashboard-status-ok-text:#047857;
+      --dashboard-status-mid:rgba(234,179,8,0.16);
+      --dashboard-status-mid-text:#b45309;
+      --dashboard-status-ko:rgba(239,68,68,0.14);
+      --dashboard-status-ko-text:#b91c1c;
+      --dashboard-status-na:rgba(148,163,184,0.18);
       --dashboard-status-na-text:#475569;
     }
-    .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(.75rem,2vw,1.5rem); }
-    .practice-dashboard.goal-modal .modal-card{ padding:0; background:var(--dashboard-surface); box-shadow:var(--dashboard-shadow); border:1px solid var(--dashboard-border); }
+    .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(1rem,2.5vw,2rem); }
+    .practice-dashboard.goal-modal .modal-card{ padding:0; background:transparent; box-shadow:none; border:0; }
     .practice-dashboard__card{
       position:relative;
-      width:min(980px,calc(100vw - 2.5rem));
-      max-height:min(94vh,820px);
+      width:min(1040px,calc(100vw - 2rem));
+      max-height:min(94vh,860px);
       display:flex;
       flex-direction:column;
-      gap:1.4rem;
-      padding:1.65rem clamp(1.35rem,3vw,2rem) 1.8rem;
+      gap:1.75rem;
+      padding:2rem clamp(1.5rem,3vw,2.5rem);
       background:var(--dashboard-surface);
+      border-radius:1.25rem;
       border:1px solid var(--dashboard-border);
-      border-radius:.75rem;
       box-shadow:var(--dashboard-shadow);
       overflow:hidden;
     }
@@ -560,221 +559,162 @@
       flex-wrap:wrap;
       align-items:flex-start;
       justify-content:space-between;
-      gap:1.25rem;
-      padding:0 0 1.05rem;
-      border-bottom:1px solid var(--dashboard-border);
+      gap:1.5rem;
     }
-    .practice-dashboard__title-group{ display:flex; flex-direction:column; gap:.35rem; max-width:min(420px,100%); }
-    .practice-dashboard__eyebrow{ font-size:.72rem; text-transform:uppercase; letter-spacing:.14em; color:#64748B; font-weight:700; }
-    .practice-dashboard__title{ font-size:1.42rem; font-weight:700; color:#111827; letter-spacing:-.01em; }
-    .practice-dashboard__subtitle{ font-size:.92rem; color:#475569; line-height:1.45; }
-    .practice-dashboard__header-actions{ display:flex; align-items:center; gap:.65rem; flex-wrap:wrap; justify-content:flex-end; padding-top:.15rem; }
-    .practice-dashboard__close{ border-color:transparent; background:#E2E8F0; color:#0f172a; transition:background .15s ease; }
-    .practice-dashboard__close:hover{ background:#CBD5F5; }
+    .practice-dashboard__title-group{ display:flex; flex-direction:column; gap:.4rem; max-width:min(460px,100%); }
+    .practice-dashboard__eyebrow{ font-size:.7rem; text-transform:uppercase; letter-spacing:.16em; color:#94a3b8; font-weight:700; }
+    .practice-dashboard__title{ font-size:1.5rem; font-weight:700; color:#0f172a; letter-spacing:-.01em; }
+    .practice-dashboard__subtitle{ font-size:.95rem; color:#475569; line-height:1.6; }
+    .practice-dashboard__header-actions{ display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; justify-content:flex-end; }
+    .practice-dashboard__close{ border-color:transparent; background:#e2e8f0; color:#0f172a; transition:background .15s ease; }
+    .practice-dashboard__close:hover{ background:#cbd5f5; }
     .practice-dashboard__close:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
-    .practice-dashboard__section{ display:flex; flex-direction:column; gap:1rem; background:#F8FAFC; border:1px solid var(--dashboard-border); border-radius:.75rem; padding:1.35rem clamp(1rem,2.6vw,1.6rem); box-shadow:var(--dashboard-shadow); overflow:hidden; }
-    .practice-dashboard__section-head{ display:flex; align-items:flex-start; justify-content:space-between; gap:.75rem; flex-wrap:wrap; padding-bottom:.85rem; border-bottom:1px solid var(--dashboard-border); }
-    .practice-dashboard__section-title{ font-weight:700; font-size:1.05rem; color:#111827; letter-spacing:-.01em; }
-    .practice-dashboard__section-subtitle{ font-size:.85rem; color:#64748B; margin-top:.2rem; }
-    .practice-dashboard__body{ flex:1 1 auto; overflow-y:auto; padding-right:.25rem; margin-right:-.25rem; display:flex; flex-direction:column; gap:1.5rem; }
-    .practice-dashboard__layout{ display:grid; grid-template-columns:minmax(0,1.1fr) minmax(0,.9fr); gap:1.35rem; align-items:flex-start; }
-    .practice-dashboard__aside{ display:flex; flex-direction:column; gap:1.1rem; }
-    .practice-dashboard__summary{ display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:.85rem; }
-    .practice-dashboard__summary-card{ display:flex; flex-direction:column; gap:.35rem; padding:1.1rem 1.2rem; border-radius:.75rem; background:#E2E8F0; border:1px solid var(--dashboard-border); box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__summary-value{ font-size:1.55rem; font-weight:700; color:#0f172a; letter-spacing:-.01em; }
-    .practice-dashboard__summary-label{ font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; color:#475569; font-weight:600; }
-    .practice-dashboard__insights{ display:flex; flex-direction:column; gap:1rem; padding:1.25rem 1.35rem; border-radius:.75rem; background:#F8FAFC; border:1px solid var(--dashboard-border); box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__insights-head{ display:flex; flex-direction:column; gap:.35rem; }
-    .practice-dashboard__insights-title{ font-size:1.02rem; font-weight:700; color:#0f172a; }
-    .practice-dashboard__insights-meta{ font-size:.8rem; color:#64748B; }
-    .practice-dashboard__insights-list{ list-style:none; padding:0; margin:0; display:grid; gap:.85rem; }
-    .practice-dashboard__insight{ display:grid; grid-template-columns:auto 1fr; gap:.75rem; align-items:flex-start; padding:.85rem; border-radius:.75rem; background:#E2E8F0; border:1px solid var(--dashboard-border); box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__insight-icon{ width:2.1rem; height:2.1rem; border-radius:999px; display:flex; align-items:center; justify-content:center; font-size:1.1rem; background:#CBD5F5; color:#1f2937; }
-    .practice-dashboard__insight-icon[data-status="ok"]{ background:var(--dashboard-status-ok); color:var(--dashboard-status-ok-text); }
-    .practice-dashboard__insight-icon[data-status="mid"]{ background:var(--dashboard-status-mid); color:var(--dashboard-status-mid-text); }
-    .practice-dashboard__insight-icon[data-status="ko"]{ background:var(--dashboard-status-ko); color:var(--dashboard-status-ko-text); }
-    .practice-dashboard__insight-icon[data-status="na"]{ background:var(--dashboard-status-na); color:var(--dashboard-status-na-text); }
-    .practice-dashboard__insight-content{ display:flex; flex-direction:column; gap:.35rem; }
-    .practice-dashboard__insight-title{ font-weight:600; font-size:.95rem; color:#0f172a; }
-    .practice-dashboard__insight-meta{ font-size:.78rem; color:#64748B; text-transform:uppercase; letter-spacing:.08em; }
-    .practice-dashboard__insight-text{ font-size:.85rem; color:#475569; line-height:1.5; margin:0; }
-    .practice-dashboard__insights-empty{ margin:0; font-size:.85rem; color:#64748B; }
-    .practice-dashboard__legend{ display:flex; flex-direction:column; gap:.6rem; padding:1.05rem 1.2rem; border-radius:.75rem; background:#F8FAFC; border:1px solid var(--dashboard-border); box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__legend-title{ font-size:.88rem; font-weight:700; color:#0f172a; }
-    .practice-dashboard__legend-list{ list-style:none; padding:0; margin:0; display:grid; gap:.5rem; font-size:.82rem; color:#475569; }
-    .practice-dashboard__legend-item{ display:flex; align-items:center; gap:.55rem; }
-    .practice-dashboard__legend-dot{ width:.75rem; height:.75rem; border-radius:999px; background:#CBD5F5; }
-    .practice-dashboard__legend-dot.is-ok{ background:var(--dashboard-status-ok-text); }
-    .practice-dashboard__legend-dot.is-mid{ background:#f59e0b; }
-    .practice-dashboard__legend-dot.is-ko{ background:#ef4444; }
-    .practice-dashboard__legend-dot.is-na{ background:#94A3B8; }
-    .practice-dashboard__table-wrapper{
-      position:relative;
-      border:1px solid var(--dashboard-border);
+    .practice-dashboard__body{ flex:1 1 auto; overflow-y:auto; padding-right:.25rem; margin-right:-.25rem; display:flex; flex-direction:column; gap:2rem; }
+    .practice-dashboard__section{
+      display:flex;
+      flex-direction:column;
+      gap:1.25rem;
+      background:linear-gradient(180deg,#ffffff 0%,#f8fafc 100%);
       border-radius:1.1rem;
-      overflow:auto;
-      background:var(--dashboard-surface);
-      box-shadow:var(--dashboard-shadow);
+      padding:clamp(1.5rem,2.4vw,2.25rem);
+      border:1px solid rgba(148,163,184,0.18);
+      box-shadow:0 16px 36px rgba(15,23,42,0.08);
     }
-    .practice-dashboard__table-wrapper::after{ display:none; }
-    .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:8px; }
-    .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:#CBD5F5; border-radius:999px; }
-    .practice-dashboard__matrix{ width:100%; border-collapse:separate; border-spacing:0; min-width:660px; }
-    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:var(--dashboard-header-bg); padding:.6rem .75rem; text-align:center; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:#64748B; border-bottom:1px solid var(--dashboard-border); z-index:5; }
-    .practice-dashboard__matrix thead th:first-child{ left:0; z-index:6; border-right:1px solid var(--dashboard-border); }
-    .practice-dashboard__matrix thead th span{ display:block; white-space:nowrap; }
-    .practice-dashboard__matrix-head-consigne{ text-align:left; min-width:220px; }
-    .practice-dashboard__matrix-consigne{ position:sticky; left:0; background:var(--dashboard-surface); padding:.75rem .9rem; border-right:1px solid var(--dashboard-border); z-index:4; }
-    .practice-dashboard__row-head{ display:flex; align-items:center; gap:.75rem; }
-    .practice-dashboard__row-indicator{ width:.45rem; height:2.5rem; border-radius:999px; background:var(--row-accent,#CBD5F5); flex-shrink:0; }
-    .practice-dashboard__row-info{ display:flex; flex-direction:column; gap:.35rem; }
-    .practice-dashboard__consigne-name{ font-weight:600; font-size:.95rem; color:#0f172a; }
-
-    .subconsigne-row {
-      display:grid;
-      grid-template-columns:minmax(0,1fr) auto;
-      gap:.75rem;
-      align-items:flex-start;
-      padding:.75rem;
-      border:1px solid #e2e8f0;
-      border-radius:.75rem;
-      background:#f8fafc;
-    }
-    .subconsigne-row__main { display:grid; gap:.5rem; }
-    .subconsigne-row__actions { display:flex; align-items:center; }
-    .subconsigne-row__actions .btn { margin-left:auto; }
-    #subconsignes-list[data-has-items] .subconsigne-empty { display:none; }
-    .subconsigne-empty {
-      font-size:.85rem;
-      color:var(--muted);
-      padding:.5rem 0;
-    }
-    .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
-    .practice-dashboard__matrix tbody td{ padding:.45rem .35rem; text-align:center; }
-    .practice-dashboard__matrix tbody tr:nth-child(even){ background:var(--dashboard-grid-stripe); }
-    .practice-dashboard__cell{ position:relative; width:100%; min-width:3.5rem; padding:.55rem .35rem; border-radius:.5rem; border:1px solid var(--dashboard-border); font-weight:600; font-size:.85rem; background:#F1F5F9; color:#0f172a; display:flex; align-items:center; justify-content:center; font-variant-numeric:tabular-nums; line-height:1.35; }
-    .practice-dashboard__cell--ok{ background:var(--dashboard-status-ok); color:var(--dashboard-status-ok-text); border-color:var(--dashboard-status-ok-text); }
-    .practice-dashboard__cell--mid{ background:var(--dashboard-status-mid); color:var(--dashboard-status-mid-text); border-color:var(--dashboard-status-mid-text); }
-    .practice-dashboard__cell--ko{ background:var(--dashboard-status-ko); color:var(--dashboard-status-ko-text); border-color:var(--dashboard-status-ko-text); }
-    .practice-dashboard__cell--na{ background:var(--dashboard-status-na); color:var(--dashboard-status-na-text); }
-    .practice-dashboard__cell--empty{ font-weight:500; }
-    .practice-dashboard__cell[data-has-note="1"]::after{ content:""; position:absolute; top:6px; right:6px; width:8px; height:8px; border-radius:999px; background:#0EA5E9; }
-    .practice-dashboard__cell:hover{ transform:none; box-shadow:var(--dashboard-shadow); border-color:var(--dashboard-border); }
-    .practice-dashboard__cell:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
-    .practice-dashboard__hint{ font-size:.82rem; color:#475569; text-align:right; }
-    .practice-dashboard__chart-panel{ display:flex; flex-direction:column; gap:1rem; }
-    .practice-dashboard__chart-scroll{ border-radius:.75rem; overflow-x:auto; padding:.55rem; padding-bottom:.25rem; margin-bottom:-.25rem; cursor:grab; -webkit-overflow-scrolling:touch; touch-action:pan-y; scroll-snap-type:x proximity; background:#F1F5F9; border:1px solid var(--dashboard-border); box-shadow:var(--dashboard-shadow); }
+    .practice-dashboard__section-head{ display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
+    .practice-dashboard__section-title{ font-weight:700; font-size:1.15rem; color:#0f172a; letter-spacing:-.01em; }
+    .practice-dashboard__section-subtitle{ font-size:.9rem; color:#64748b; margin:0; }
+    .practice-dashboard__chart-panel{ display:flex; flex-direction:column; gap:1.25rem; }
+    .practice-dashboard__chart-scroll{ border-radius:1rem; overflow-x:auto; padding:.75rem; cursor:grab; -webkit-overflow-scrolling:touch; touch-action:pan-y; background:#fff; border:1px solid rgba(148,163,184,0.2); box-shadow:0 12px 28px rgba(15,23,42,0.08); }
     .practice-dashboard__chart-scroll:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__chart-scroll.is-dragging{ cursor:grabbing; user-select:none; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar{ height:10px; }
-    .practice-dashboard__chart-scroll::-webkit-scrollbar-track{ background:transparent; }
-    .practice-dashboard__chart-scroll::-webkit-scrollbar-thumb{ background:#CBD5F5; border-radius:999px; }
+    .practice-dashboard__chart-scroll::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.4); border-radius:999px; }
     .practice-dashboard__chart-card{
       position:relative;
-      border:1px solid var(--dashboard-border);
-      border-radius:.75rem;
-      background:var(--dashboard-surface);
-      padding:1rem 1.25rem 1.2rem;
-      min-height:240px;
-      box-shadow:var(--dashboard-shadow);
+      border:1px solid rgba(148,163,184,0.2);
+      border-radius:1rem;
+      background:#fff;
+      padding:1.1rem 1.4rem 1.4rem;
+      min-height:260px;
+      box-shadow:0 14px 32px rgba(15,23,42,0.08);
     }
-    .practice-dashboard__chart-card::before{ content:none; }
-    .practice-dashboard__chart-canvas{ position:relative; min-height:220px; min-width:520px; }
+    .practice-dashboard__chart-canvas{ position:relative; min-height:240px; min-width:540px; }
     .practice-dashboard__chart-card canvas{ width:100%; height:100%; }
-    .practice-dashboard__chart-caption{ font-size:.82rem; color:#475569; background:#F1F5F9; border-radius:.5rem; padding:.55rem .75rem; box-shadow:var(--dashboard-shadow); }
+    .practice-dashboard__chart-caption{ font-size:.82rem; color:#475569; background:#f8fafc; border-radius:.75rem; padding:.65rem .9rem; box-shadow:0 10px 24px rgba(15,23,42,0.06); }
     .practice-dashboard__chart-caption:empty{ display:none; }
-    .practice-dashboard__chart-actions{ display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:.85rem; padding-top:.9rem; border-top:1px solid var(--dashboard-border); }
-    .practice-dashboard__chart-controls{ display:flex; flex-wrap:wrap; gap:.6rem; align-items:center; justify-content:flex-end; margin-top:0; flex:1 1 260px; }
-    .practice-dashboard__chart-zoom{ display:inline-flex; flex-wrap:wrap; gap:.35rem; align-items:center; padding:.35rem .4rem; border-radius:.75rem; background:#F1F5F9; border:1px solid var(--dashboard-border); box-shadow:var(--dashboard-shadow); flex:0 0 auto; }
-    .practice-dashboard__zoom-btn{ border:1px solid var(--dashboard-border); background:#E2E8F0; border-radius:.75rem; padding:.45rem 1rem; font-size:.82rem; font-weight:600; color:#1f2937; transition:background .15s ease,color .15s ease,border-color .15s ease; }
-    .practice-dashboard__zoom-btn:hover{ background:#CBD5F5; }
-    .practice-dashboard__zoom-btn.is-active{ background:var(--accent-600); color:#fff; border-color:var(--accent-600); box-shadow:var(--dashboard-shadow); cursor:default; }
-    .practice-dashboard__footer{ margin-top:auto; padding-top:1rem; border-top:1px solid var(--dashboard-border); display:flex; align-items:center; justify-content:flex-end; gap:.75rem; }
-    .practice-dashboard__footer-actions{ display:flex; gap:.6rem; }
-    .practice-dashboard__filter{ display:flex; flex-direction:column; gap:.3rem; font-size:.78rem; color:#475569; }
-    .practice-dashboard__filter-label{ font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:#0f172a; }
-    .practice-dashboard__filter-select{ border:1px solid var(--dashboard-border); border-radius:.8rem; padding:.4rem .7rem; font-size:.88rem; color:#0f172a; background:#fff; min-width:180px; box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__filter-select:focus-visible{ outline:3px solid var(--accent-200); outline-offset:1px; border-color:var(--accent-400); }
+    .practice-dashboard__chart-actions{ display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:1rem; padding-top:.25rem; }
+    .practice-dashboard__chart-zoom{ display:inline-flex; flex-wrap:wrap; gap:.45rem; align-items:center; padding:.4rem .5rem; border-radius:.9rem; background:#fff; border:1px solid rgba(148,163,184,0.2); box-shadow:0 8px 20px rgba(15,23,42,0.06); }
+    .practice-dashboard__chart-controls{ display:flex; flex-wrap:wrap; gap:.6rem; align-items:center; justify-content:flex-end; }
+    .practice-dashboard__zoom-btn{ border:1px solid transparent; background:rgba(148,163,184,0.16); border-radius:.75rem; padding:.45rem 1rem; font-size:.82rem; font-weight:600; color:#1f2937; transition:background .15s ease,color .15s ease,border-color .15s ease; }
+    .practice-dashboard__zoom-btn:hover{ background:rgba(148,163,184,0.26); }
+    .practice-dashboard__zoom-btn.is-active{ background:var(--accent-600); color:#fff; border-color:var(--accent-600); box-shadow:0 6px 18px rgba(59,130,246,0.35); cursor:default; }
     .practice-dashboard__view-toggle{
       display:inline-flex;
       align-items:center;
-      gap:.25rem;
-      padding:.35rem;
-      border-radius:.75rem;
-      background:#F1F5F9;
-      box-shadow:var(--dashboard-shadow);
-      border:1px solid var(--dashboard-border);
+      gap:.35rem;
+      padding:.4rem;
+      border-radius:.9rem;
+      background:#fff;
+      box-shadow:0 8px 20px rgba(15,23,42,0.08);
+      border:1px solid rgba(148,163,184,0.2);
     }
-    .practice-dashboard__view-btn{ border:0; background:transparent; padding:.45rem 1rem; border-radius:.8rem; font-size:.82rem; font-weight:600; color:#1f2937; cursor:pointer; transition:background .15s ease,color .15s ease,box-shadow .15s ease; }
-    .practice-dashboard__view-btn:hover:not(:disabled){ background:#f1f5f9; }
-    .practice-dashboard__view-btn.is-active{ background:var(--accent-600); color:#fff; box-shadow:var(--dashboard-shadow); }
+    .practice-dashboard__view-btn{ border:0; background:transparent; padding:.5rem 1.1rem; border-radius:.75rem; font-size:.82rem; font-weight:600; color:#1f2937; cursor:pointer; transition:background .15s ease,color .15s ease,box-shadow .15s ease; }
+    .practice-dashboard__view-btn:hover:not(:disabled){ background:rgba(148,163,184,0.14); }
+    .practice-dashboard__view-btn.is-active{ background:var(--accent-600); color:#fff; box-shadow:0 6px 18px rgba(59,130,246,0.35); }
     .practice-dashboard__view-btn:disabled{ opacity:.55; cursor:default; }
     .practice-dashboard__view-btn:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
-    .practice-dashboard__chart-option{ display:inline-flex; align-items:center; gap:.4rem; padding:.4rem .7rem; border-radius:.75rem; background:#F1F5F9; border:1px solid var(--dashboard-border); font-size:.82rem; color:#1f2937; box-shadow:var(--dashboard-shadow); }
-    .practice-dashboard__chart-option input{ accent-color:var(--accent-600); }
-    .practice-dashboard__chart-empty{ font-size:.85rem; color:#64748B; }
-    .practice-dashboard__empty{ padding:1.25rem; border-radius:1rem; border:1px dashed #CBD5F5; background:#F8FAFC; font-size:.9rem; color:#475569; text-align:center; }
-    .practice-dashboard__empty-row{ padding:2rem 1rem; text-align:center; font-size:.9rem; color:#94A3B8; }
-    @media (min-width: 1024px){
-      .practice-dashboard__layout{ grid-template-columns:minmax(0,1.05fr) minmax(0,.95fr); gap:1.5rem; }
-      .practice-dashboard__section--chart{ height:100%; }
+    .practice-dashboard__filter{ display:flex; flex-direction:column; gap:.3rem; font-size:.78rem; color:#475569; }
+    .practice-dashboard__filter-label{ font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:#0f172a; }
+    .practice-dashboard__filter-select{ border:1px solid rgba(148,163,184,0.35); border-radius:.8rem; padding:.45rem .75rem; font-size:.9rem; color:#0f172a; background:#fff; box-shadow:0 8px 20px rgba(15,23,42,0.05); }
+    .practice-dashboard__filter-select:focus-visible{ outline:3px solid var(--accent-200); outline-offset:1px; border-color:var(--accent-400); }
+    .practice-dashboard__table-wrapper{
+      border-radius:1rem;
+      border:1px solid rgba(148,163,184,0.2);
+      background:#fff;
+      overflow:auto;
+      box-shadow:0 16px 32px rgba(15,23,42,0.08);
     }
+    .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:8px; }
+    .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.4); border-radius:999px; }
+    .practice-dashboard__matrix{ width:100%; border-collapse:collapse; min-width:640px; }
+    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:var(--dashboard-header-bg); padding:.75rem 1rem; text-align:left; font-size:.72rem; text-transform:uppercase; letter-spacing:.08em; color:#64748b; border-bottom:1px solid rgba(148,163,184,0.2); z-index:2; }
+    .practice-dashboard__matrix-head-consigne{ min-width:220px; }
+    .practice-dashboard__matrix-consigne{ background:#fff; padding:.85rem 1rem; font-weight:600; color:#0f172a; text-align:left; }
+    .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
+    .practice-dashboard__consigne-name{ font-size:.98rem; }
+    .practice-dashboard__matrix tbody td{ padding:.45rem 0; text-align:center; }
+    .practice-dashboard__matrix tbody tr:nth-child(even){ background:var(--dashboard-grid-stripe); }
+    .practice-dashboard__cell{
+      position:relative;
+      width:100%;
+      min-width:3.5rem;
+      padding:.65rem .5rem;
+      border-radius:.6rem;
+      border:1px solid transparent;
+      font-weight:600;
+      font-size:.88rem;
+      background:transparent;
+      color:#0f172a;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-variant-numeric:tabular-nums;
+      line-height:1.4;
+    }
+    .practice-dashboard__cell--ok{ background:var(--dashboard-status-ok); color:var(--dashboard-status-ok-text); border-color:rgba(16,185,129,0.25); }
+    .practice-dashboard__cell--mid{ background:var(--dashboard-status-mid); color:var(--dashboard-status-mid-text); border-color:rgba(234,179,8,0.25); }
+    .practice-dashboard__cell--ko{ background:var(--dashboard-status-ko); color:var(--dashboard-status-ko-text); border-color:rgba(239,68,68,0.2); }
+    .practice-dashboard__cell--na{ background:var(--dashboard-status-na); color:var(--dashboard-status-na-text); border-color:rgba(148,163,184,0.3); }
+    .practice-dashboard__cell--empty{ font-weight:500; color:#94a3b8; }
+    .practice-dashboard__cell[data-has-note="1"]::after{ content:""; position:absolute; top:8px; right:8px; width:8px; height:8px; border-radius:999px; background:#38bdf8; }
+    .practice-dashboard__cell:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
+    .practice-dashboard__hint{ font-size:.82rem; color:#64748b; text-align:right; }
+    .practice-dashboard__chart-option{ display:inline-flex; align-items:center; gap:.4rem; padding:.4rem .7rem; border-radius:.75rem; background:#fff; border:1px solid rgba(148,163,184,0.2); font-size:.82rem; color:#1f2937; box-shadow:0 8px 20px rgba(15,23,42,0.08); }
+    .practice-dashboard__chart-option input{ accent-color:var(--accent-600); }
+    .practice-dashboard__chart-empty{ font-size:.85rem; color:#64748b; }
+    .practice-dashboard__empty{ padding:1.5rem; border-radius:1rem; border:1px dashed rgba(148,163,184,0.35); background:#f8fafc; font-size:.9rem; color:#475569; text-align:center; }
+    .practice-dashboard__empty-row{ padding:2rem 1rem; text-align:center; font-size:.9rem; color:#94A3B8; }
+    .practice-dashboard__footer{ margin-top:auto; padding-top:1.25rem; border-top:1px solid rgba(148,163,184,0.2); display:flex; align-items:center; justify-content:flex-end; gap:.75rem; }
+    .practice-dashboard__footer-actions{ display:flex; gap:.6rem; }
     @media (max-width: 1024px){
-      .practice-dashboard__card{ width:min(100%,calc(100vw - 1.5rem)); }
-      .practice-dashboard__layout{ grid-template-columns:1fr; }
+      .practice-dashboard__card{ width:min(100%,calc(100vw - 1.5rem)); padding:1.75rem clamp(1.1rem,4vw,2rem); }
+      .practice-dashboard__body{ padding-right:0; margin-right:0; gap:1.6rem; }
+      .practice-dashboard__header{ flex-direction:column; align-items:flex-start; gap:1rem; }
+      .practice-dashboard__header-actions{ width:100%; justify-content:space-between; }
     }
     @media (max-width: 768px){
       .practice-dashboard.goal-modal{ padding:0; align-items:stretch; }
-      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:var(--dashboard-shadow); border:1px solid var(--dashboard-border); padding:1.35rem clamp(1rem,4vw,1.5rem) 1.6rem; }
-      .practice-dashboard.goal-modal .practice-dashboard__card{ padding-top:calc(env(safe-area-inset-top,0) + 1.35rem); }
-      .practice-dashboard__body{ padding-right:0; margin-right:0; gap:1.35rem; }
-      .practice-dashboard__layout{ gap:1.2rem; }
-      .practice-dashboard__aside{ order:-1; }
-      .practice-dashboard__header{ flex-direction:column; align-items:flex-start; gap:.85rem; padding:.15rem 0 .85rem; border-bottom:1px solid var(--dashboard-border); }
-      .practice-dashboard__header-actions{ width:100%; flex-direction:column; align-items:stretch; gap:.6rem; justify-content:flex-start; padding-top:0; }
+      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:none; border:0; padding:1.4rem clamp(1rem,4vw,1.6rem) 1.8rem; }
+      .practice-dashboard.goal-modal .practice-dashboard__card{ padding-top:calc(env(safe-area-inset-top,0) + 1.4rem); }
       .practice-dashboard__view-toggle{ width:100%; justify-content:space-between; }
       .practice-dashboard__view-btn{ flex:1 1 auto; text-align:center; }
       .practice-dashboard__filter-select{ width:100%; }
-      .practice-dashboard__chart-panel{ gap:.75rem; }
-      .practice-dashboard__chart-card{ min-height:220px; padding:.95rem 1.05rem 1.15rem; }
+      .practice-dashboard__chart-card{ min-height:220px; padding:1rem 1.1rem 1.25rem; }
       .practice-dashboard__chart-canvas{ min-width:min(520px,100%); }
-      .practice-dashboard__chart-actions{ flex-direction:column; align-items:stretch; }
-      .practice-dashboard__chart-zoom,
-      .practice-dashboard__chart-controls{ flex-direction:column; align-items:stretch; gap:.45rem; }
-      .practice-dashboard__chart-option{ justify-content:space-between; }
-      .practice-dashboard__table-wrapper{ box-shadow:var(--dashboard-shadow); }
+      .practice-dashboard__chart-actions{ flex-direction:column; align-items:stretch; gap:.75rem; }
+      .practice-dashboard__chart-controls{ justify-content:flex-start; }
+      .practice-dashboard__chart-zoom{ justify-content:space-between; }
+      .practice-dashboard__table-wrapper{ box-shadow:0 10px 24px rgba(15,23,42,0.08); }
       .practice-dashboard__hint{ text-align:left; }
       .practice-dashboard__footer{ flex-direction:column; align-items:stretch; gap:.65rem; }
       .practice-dashboard__footer-actions{ justify-content:flex-end; }
     }
     @media (max-width: 640px){
-      .practice-dashboard__title{ font-size:1.12rem; }
-      .practice-dashboard__section-title{ font-size:.95rem; }
-      .practice-dashboard__subtitle{ font-size:.88rem; }
-      .practice-dashboard__summary{ grid-template-columns:1fr; }
-      .practice-dashboard__insight{ grid-template-columns:1fr; }
-      .practice-dashboard__insight-icon{ width:1.85rem; height:1.85rem; }
-      .practice-dashboard__table-wrapper{ padding:0; background:transparent; border:0; box-shadow:none; overflow:visible; }
-      .practice-dashboard__table-wrapper::after{ display:none; }
-      .practice-dashboard__matrix{ width:100%; min-width:0; border-collapse:separate; border-spacing:0; }
+      .practice-dashboard__title{ font-size:1.25rem; }
+      .practice-dashboard__section-title{ font-size:1rem; }
+      .practice-dashboard__subtitle{ font-size:.9rem; }
+      .practice-dashboard__section{ padding:1.35rem clamp(1rem,4vw,1.6rem); }
+      .practice-dashboard__chart-scroll{ padding:.6rem; }
+      .practice-dashboard__matrix{ min-width:0; }
       .practice-dashboard__matrix thead{ display:none; }
       .practice-dashboard__matrix tbody{ display:flex; flex-direction:column; gap:1rem; }
-      .practice-dashboard__matrix tbody tr{ position:relative; display:flex; flex-direction:column; gap:.75rem; padding:1rem clamp(.75rem,4vw,1.25rem); border-radius:.75rem; background:#F8FAFC; box-shadow:var(--dashboard-shadow); border:1px solid var(--dashboard-border); }
+      .practice-dashboard__matrix tbody tr{ display:flex; flex-direction:column; gap:.85rem; padding:1rem clamp(.75rem,4vw,1.25rem); border-radius:1rem; background:#fff; box-shadow:0 12px 28px rgba(15,23,42,0.08); border:1px solid rgba(148,163,184,0.2); }
+      .practice-dashboard__matrix-consigne{ padding:0; }
       .practice-dashboard__matrix tbody td{ padding:0; text-align:left; }
-      .practice-dashboard__matrix-consigne{ position:static; left:auto; background:transparent; padding:0; border-right:0; box-shadow:none; }
-      .practice-dashboard__row-head{ gap:.65rem; align-items:flex-start; }
-      .practice-dashboard__row-indicator{ height:1.75rem; }
-      .practice-dashboard__row-info{ gap:.2rem; }
-      .practice-dashboard__matrix tbody tr::after{ content:none; }
-      .practice-dashboard__matrix tbody tr > *{ position:relative; z-index:1; }
-      .practice-dashboard__matrix tbody tr:nth-child(even)::after{ background:none; }
-      .practice-dashboard__cell{ width:100%; min-width:0; padding:.65rem .75rem; justify-content:flex-start; align-items:flex-start; gap:.35rem; text-align:left; font-size:.92rem; }
-      .practice-dashboard__cell::before{ content:attr(data-label); font-size:.7rem; font-weight:600; letter-spacing:.08em; text-transform:uppercase; color:#64748B; }
-      .practice-dashboard__cell[data-has-note="1"]::after{ top:8px; right:8px; }
-      .practice-dashboard__cell:hover{ transform:none; box-shadow:var(--dashboard-shadow); }
-      .practice-dashboard__hint{ margin-top:-.25rem; }
+      .practice-dashboard__cell{ width:100%; min-width:0; justify-content:flex-start; align-items:flex-start; gap:.4rem; text-align:left; font-size:.95rem; padding:.65rem .7rem; }
+      .practice-dashboard__cell::before{ content:attr(data-label); font-size:.7rem; font-weight:600; letter-spacing:.08em; text-transform:uppercase; color:#94a3b8; }
+      .practice-dashboard__hint{ margin-top:-.15rem; }
     }
-
     .practice-editor{ display:flex; flex-direction:column; gap:1rem; }
     .practice-editor__header{ display:flex; flex-direction:column; gap:.25rem; }
     .practice-editor__title{ font-size:1.05rem; font-weight:600; color:#0f172a; }


### PR DESCRIPTION
## Summary
- simplify the dashboard modal to focus on the chart and table views only, removing summary, insight, and legend panels
- restyle the dashboard surface for a cleaner minimalist presentation and lighten the matrix/table appearance
- streamline the table row markup for a simpler Excel-like layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5998e5f208333b77d98016a071c92