### PR TITLE
Simplify practice dashboard layout and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@
       --dashboard-status-na:rgba(148,163,184,0.18);
       --dashboard-status-na-text:#475569;
     }
-    .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(1rem,2.5vw,2rem); }
+    .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(1.5rem,3vw,2.5rem); }
     .practice-dashboard.goal-modal .modal-card{ padding:0; background:transparent; box-shadow:none; border:0; }
     .practice-dashboard__card{
       position:relative;
@@ -546,12 +546,12 @@
       max-height:min(94vh,860px);
       display:flex;
       flex-direction:column;
-      gap:1.75rem;
-      padding:2rem clamp(1.5rem,3vw,2.5rem);
-      background:var(--dashboard-surface);
-      border-radius:1.25rem;
-      border:1px solid var(--dashboard-border);
-      box-shadow:var(--dashboard-shadow);
+      gap:1.5rem;
+      padding:2.25rem clamp(1.5rem,3vw,2.6rem);
+      background:#fff;
+      border-radius:1.35rem;
+      border:1px solid rgba(15,23,42,0.08);
+      box-shadow:0 20px 48px rgba(15,23,42,0.14);
       overflow:hidden;
     }
     .practice-dashboard__header{
@@ -574,40 +574,36 @@
       display:flex;
       flex-direction:column;
       gap:1.25rem;
-      background:linear-gradient(180deg,#ffffff 0%,#f8fafc 100%);
-      border-radius:1.1rem;
-      padding:clamp(1.5rem,2.4vw,2.25rem);
-      border:1px solid rgba(148,163,184,0.18);
-      box-shadow:0 16px 36px rgba(15,23,42,0.08);
+      background:#fff;
+      border-radius:1rem;
+      padding:clamp(1.4rem,2.2vw,2rem);
+      border:1px solid rgba(148,163,184,0.16);
+      box-shadow:none;
     }
     .practice-dashboard__section-head{ display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
     .practice-dashboard__section-title{ font-weight:700; font-size:1.15rem; color:#0f172a; letter-spacing:-.01em; }
     .practice-dashboard__section-subtitle{ font-size:.9rem; color:#64748b; margin:0; }
     .practice-dashboard__chart-panel{ display:flex; flex-direction:column; gap:1.25rem; }
-    .practice-dashboard__chart-scroll{ border-radius:1rem; overflow-x:auto; padding:.75rem; cursor:grab; -webkit-overflow-scrolling:touch; touch-action:pan-y; background:#fff; border:1px solid rgba(148,163,184,0.2); box-shadow:0 12px 28px rgba(15,23,42,0.08); }
+    .practice-dashboard__chart-scroll{ border-radius:1rem; overflow-x:auto; padding:1rem; cursor:grab; -webkit-overflow-scrolling:touch; touch-action:pan-y; background:#fff; border:1px solid rgba(148,163,184,0.2); box-shadow:0 8px 20px rgba(15,23,42,0.06); scrollbar-color:#94a3b8 rgba(226,232,240,0.65); }
     .practice-dashboard__chart-scroll:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__chart-scroll.is-dragging{ cursor:grabbing; user-select:none; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar{ height:10px; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.4); border-radius:999px; }
     .practice-dashboard__chart-card{
       position:relative;
-      border:1px solid rgba(148,163,184,0.2);
+      border:1px solid rgba(148,163,184,0.18);
       border-radius:1rem;
       background:#fff;
-      padding:1.1rem 1.4rem 1.4rem;
+      padding:1.25rem 1.5rem 1.6rem;
       min-height:260px;
-      box-shadow:0 14px 32px rgba(15,23,42,0.08);
+      box-shadow:0 10px 28px rgba(15,23,42,0.08);
     }
-    .practice-dashboard__chart-canvas{ position:relative; min-height:240px; min-width:540px; }
+    .practice-dashboard__chart-canvas{ position:relative; min-height:240px; min-width:540px; margin:0 auto; }
     .practice-dashboard__chart-card canvas{ width:100%; height:100%; }
-    .practice-dashboard__chart-caption{ font-size:.82rem; color:#475569; background:#f8fafc; border-radius:.75rem; padding:.65rem .9rem; box-shadow:0 10px 24px rgba(15,23,42,0.06); }
+    .practice-dashboard__chart-caption{ font-size:.82rem; color:#475569; background:#f8fafc; border-radius:.75rem; padding:.65rem .9rem; box-shadow:0 6px 18px rgba(15,23,42,0.05); }
     .practice-dashboard__chart-caption:empty{ display:none; }
-    .practice-dashboard__chart-actions{ display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:1rem; padding-top:.25rem; }
-    .practice-dashboard__chart-zoom{ display:inline-flex; flex-wrap:wrap; gap:.45rem; align-items:center; padding:.4rem .5rem; border-radius:.9rem; background:#fff; border:1px solid rgba(148,163,184,0.2); box-shadow:0 8px 20px rgba(15,23,42,0.06); }
-    .practice-dashboard__chart-controls{ display:flex; flex-wrap:wrap; gap:.6rem; align-items:center; justify-content:flex-end; }
-    .practice-dashboard__zoom-btn{ border:1px solid transparent; background:rgba(148,163,184,0.16); border-radius:.75rem; padding:.45rem 1rem; font-size:.82rem; font-weight:600; color:#1f2937; transition:background .15s ease,color .15s ease,border-color .15s ease; }
-    .practice-dashboard__zoom-btn:hover{ background:rgba(148,163,184,0.26); }
-    .practice-dashboard__zoom-btn.is-active{ background:var(--accent-600); color:#fff; border-color:var(--accent-600); box-shadow:0 6px 18px rgba(59,130,246,0.35); cursor:default; }
+    .practice-dashboard__chart-actions{ display:flex; flex-direction:column; align-items:flex-start; gap:1rem; padding-top:.25rem; }
+    .practice-dashboard__chart-controls{ display:flex; flex-direction:column; gap:.65rem; align-items:flex-start; width:100%; }
     .practice-dashboard__view-toggle{
       display:inline-flex;
       align-items:center;
@@ -629,13 +625,14 @@
     .practice-dashboard__filter-select:focus-visible{ outline:3px solid var(--accent-200); outline-offset:1px; border-color:var(--accent-400); }
     .practice-dashboard__table-wrapper{
       border-radius:1rem;
-      border:1px solid rgba(148,163,184,0.2);
+      border:1px solid rgba(148,163,184,0.18);
       background:#fff;
       overflow:auto;
-      box-shadow:0 16px 32px rgba(15,23,42,0.08);
+      box-shadow:0 12px 28px rgba(15,23,42,0.08);
+      scrollbar-color:#94a3b8 rgba(226,232,240,0.65);
     }
-    .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:8px; }
-    .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.4); border-radius:999px; }
+    .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:10px; }
+    .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.45); border-radius:999px; }
     .practice-dashboard__matrix{ width:100%; border-collapse:collapse; min-width:640px; }
     .practice-dashboard__matrix thead th{ position:sticky; top:0; background:var(--dashboard-header-bg); padding:.75rem 1rem; text-align:left; font-size:.72rem; text-transform:uppercase; letter-spacing:.08em; color:#64748b; border-bottom:1px solid rgba(148,163,184,0.2); z-index:2; }
     .practice-dashboard__matrix-head-consigne{ min-width:220px; }
@@ -643,7 +640,7 @@
     .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
     .practice-dashboard__consigne-name{ font-size:.98rem; }
     .practice-dashboard__matrix tbody td{ padding:.45rem 0; text-align:center; }
-    .practice-dashboard__matrix tbody tr:nth-child(even){ background:var(--dashboard-grid-stripe); }
+    .practice-dashboard__matrix tbody tr:nth-child(even){ background:rgba(148,163,184,0.08); }
     .practice-dashboard__cell{
       position:relative;
       width:100%;
@@ -669,7 +666,8 @@
     .practice-dashboard__cell[data-has-note="1"]::after{ content:""; position:absolute; top:8px; right:8px; width:8px; height:8px; border-radius:999px; background:#38bdf8; }
     .practice-dashboard__cell:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__hint{ font-size:.82rem; color:#64748b; text-align:right; }
-    .practice-dashboard__chart-option{ display:inline-flex; align-items:center; gap:.4rem; padding:.4rem .7rem; border-radius:.75rem; background:#fff; border:1px solid rgba(148,163,184,0.2); font-size:.82rem; color:#1f2937; box-shadow:0 8px 20px rgba(15,23,42,0.08); }
+    .practice-dashboard__chart-option{ display:flex; align-items:center; gap:.55rem; padding:.35rem .75rem; border-radius:.75rem; background:#f8fafc; border:1px solid rgba(148,163,184,0.35); font-size:.85rem; color:#1f2937; width:100%; transition:background .15s ease,border-color .15s ease,box-shadow .15s ease; }
+    .practice-dashboard__chart-option:hover{ background:#e2e8f0; border-color:rgba(148,163,184,0.55); box-shadow:0 4px 12px rgba(15,23,42,0.08); }
     .practice-dashboard__chart-option input{ accent-color:var(--accent-600); }
     .practice-dashboard__chart-empty{ font-size:.85rem; color:#64748b; }
     .practice-dashboard__empty{ padding:1.5rem; border-radius:1rem; border:1px dashed rgba(148,163,184,0.35); background:#f8fafc; font-size:.9rem; color:#475569; text-align:center; }
@@ -691,9 +689,8 @@
       .practice-dashboard__filter-select{ width:100%; }
       .practice-dashboard__chart-card{ min-height:220px; padding:1rem 1.1rem 1.25rem; }
       .practice-dashboard__chart-canvas{ min-width:min(520px,100%); }
-      .practice-dashboard__chart-actions{ flex-direction:column; align-items:stretch; gap:.75rem; }
-      .practice-dashboard__chart-controls{ justify-content:flex-start; }
-      .practice-dashboard__chart-zoom{ justify-content:space-between; }
+        .practice-dashboard__chart-actions{ flex-direction:column; align-items:stretch; gap:.75rem; }
+        .practice-dashboard__chart-controls{ justify-content:flex-start; }
       .practice-dashboard__table-wrapper{ box-shadow:0 10px 24px rgba(15,23,42,0.08); }
       .practice-dashboard__hint{ text-align:left; }
       .practice-dashboard__footer{ flex-direction:column; align-items:stretch; gap:.65rem; }


### PR DESCRIPTION
## Summary
- refresh the practice dashboard modal styling to create a single minimal white surface with softer shadows and table enhancements
- simplify the chart controls by removing zoom presets, centering the initial view, and presenting the consigne toggles in a vertical list with cleaner caption text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d59da89788833396a77824e1dc252c