### PR TITLE
Refine practice dashboard modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,16 +542,16 @@
     .practice-dashboard.goal-modal .modal-card{ padding:0; background:transparent; box-shadow:none; border:0; }
     .practice-dashboard__card{
       position:relative;
-      width:min(1040px,calc(100vw - 2rem));
-      max-height:min(94vh,860px);
-      display:flex;
-      flex-direction:column;
-      gap:1.5rem;
-      padding:2.25rem clamp(1.5rem,3vw,2.6rem);
+      width:min(980px,calc(100vw - 2rem));
+      max-height:clamp(480px,72vh,840px);
+      display:grid;
+      grid-template-rows:auto 1fr auto;
+      gap:0;
+      padding:0;
       background:#fff;
-      border-radius:1.35rem;
-      border:1px solid rgba(15,23,42,0.08);
-      box-shadow:0 20px 48px rgba(15,23,42,0.14);
+      border-radius:1.5rem;
+      border:1px solid rgba(15,23,42,0.12);
+      box-shadow:0 28px 52px rgba(15,23,42,0.18);
       overflow:hidden;
     }
     .practice-dashboard__header{
@@ -559,87 +559,80 @@
       flex-wrap:wrap;
       align-items:flex-start;
       justify-content:space-between;
-      gap:1.5rem;
+      gap:1.25rem;
+      padding:1.75rem clamp(1.5rem,3vw,2.25rem) 1.4rem;
       background:#fff;
-      border:1px solid rgba(148,163,184,0.16);
-      border-radius:1.2rem;
-      padding:1.35rem clamp(1.2rem,2vw,1.75rem);
-      box-shadow:0 16px 32px rgba(15,23,42,0.1);
+      border-bottom:1px solid rgba(148,163,184,0.16);
     }
     .practice-dashboard__title-group{ display:flex; flex-direction:column; gap:.4rem; max-width:min(460px,100%); }
     .practice-dashboard__eyebrow{ font-size:.7rem; text-transform:uppercase; letter-spacing:.16em; color:#94a3b8; font-weight:700; }
-    .practice-dashboard__title{ font-size:1.5rem; font-weight:700; color:#0f172a; letter-spacing:-.01em; }
-    .practice-dashboard__subtitle{ font-size:.95rem; color:#475569; line-height:1.6; }
+    .practice-dashboard__title{ font-size:1.6rem; font-weight:700; color:#0f172a; letter-spacing:-.02em; }
+    .practice-dashboard__subtitle{ font-size:.9rem; color:#475569; line-height:1.6; max-width:560px; }
     .practice-dashboard__header-actions{
       display:flex;
       align-items:center;
-      gap:.9rem;
+      gap:.75rem;
       flex-wrap:wrap;
       justify-content:flex-end;
-      background:#f8fafc;
-      border-radius:1rem;
-      padding:.75rem clamp(.85rem,2vw,1.15rem);
-      border:1px solid rgba(148,163,184,0.18);
-      box-shadow:0 12px 28px rgba(15,23,42,0.08);
     }
     .practice-dashboard__close{ border-color:transparent; background:#e2e8f0; color:#0f172a; transition:background .15s ease; }
     .practice-dashboard__close:hover{ background:#cbd5f5; }
     .practice-dashboard__close:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__body{
-      flex:1 1 auto;
       overflow-y:auto;
-      padding-right:.25rem;
-      margin-right:-.25rem;
-      padding-bottom:2.5rem;
+      padding:1.75rem clamp(1.5rem,3vw,2.25rem);
       display:flex;
       flex-direction:column;
-      gap:2rem;
+      gap:1.5rem;
+      background:#f8fafc;
+      min-height:0;
     }
     .practice-dashboard__section{
       display:flex;
       flex-direction:column;
-      gap:1.25rem;
+      gap:1.1rem;
       background:#fff;
-      border-radius:1rem;
-      padding:clamp(1.4rem,2.2vw,2rem);
-      border:1px solid rgba(148,163,184,0.16);
-      box-shadow:none;
+      border-radius:1.1rem;
+      padding:clamp(1.2rem,2vw,1.75rem);
+      border:1px solid rgba(148,163,184,0.14);
+      box-shadow:0 10px 26px rgba(15,23,42,0.08);
     }
     .practice-dashboard__section-head{ display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
-    .practice-dashboard__section-title{ font-weight:700; font-size:1.15rem; color:#0f172a; letter-spacing:-.01em; }
-    .practice-dashboard__section-subtitle{ font-size:.9rem; color:#64748b; margin:0; }
+    .practice-dashboard__section-title{ font-weight:700; font-size:1.05rem; color:#0f172a; letter-spacing:-.01em; }
+    .practice-dashboard__section-subtitle{ font-size:.85rem; color:#64748b; margin:0; }
     .practice-dashboard__chart-panel{
       display:flex;
       flex-direction:column;
-      gap:1.25rem;
+      gap:1.1rem;
       background:#fff;
-      border-radius:1.2rem;
-      padding:1.25rem clamp(1rem,2.2vw,1.75rem);
-      border:1px solid rgba(148,163,184,0.16);
-      box-shadow:0 18px 36px rgba(15,23,42,0.08);
+      border-radius:1rem;
+      padding:1.1rem clamp(.95rem,2vw,1.5rem);
+      border:1px solid rgba(148,163,184,0.14);
+      box-shadow:none;
     }
-    .practice-dashboard__chart-scroll{ border-radius:1rem; overflow-x:auto; padding:1rem; cursor:grab; -webkit-overflow-scrolling:touch; touch-action:pan-y; background:#fff; border:1px solid rgba(148,163,184,0.2); box-shadow:0 8px 20px rgba(15,23,42,0.06); scrollbar-color:#94a3b8 rgba(226,232,240,0.65); }
+    .practice-dashboard__chart-scroll{ border-radius:.85rem; overflow:hidden; padding:.35rem; background:#f8fafc; border:1px solid rgba(148,163,184,0.18); }
     .practice-dashboard__chart-scroll:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__chart-scroll.is-dragging{ cursor:grabbing; user-select:none; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar{ height:10px; }
     .practice-dashboard__chart-scroll::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.4); border-radius:999px; }
     .practice-dashboard__chart-card{
       position:relative;
-      border:1px solid rgba(148,163,184,0.18);
-      border-radius:1rem;
+      border:1px solid rgba(148,163,184,0.16);
+      border-radius:.95rem;
       background:#fff;
-      padding:1.25rem 1.5rem 1.6rem;
-      min-height:182px;
-      box-shadow:0 10px 24px rgba(15,23,42,0.08);
+      padding:1.1rem 1.25rem 1.35rem;
+      min-height:160px;
+      box-shadow:none;
     }
     .practice-dashboard__chart-canvas{
       position:relative;
-      min-height:170px;
-      min-width:540px;
-      margin:0 auto;
-      padding:.5rem;
+      min-height:160px;
+      width:100%;
+      min-width:0;
+      margin:0;
+      padding:.35rem;
       background:#fff;
-      border-radius:.85rem;
+      border-radius:.75rem;
       box-shadow:inset 0 0 0 1px rgba(148,163,184,0.12);
     }
     .practice-dashboard__chart-card canvas{
@@ -650,19 +643,18 @@
       border-radius:.75rem;
     }
     .practice-dashboard__chart-caption{
-      font-size:.78rem;
+      font-size:.82rem;
       color:#475569;
-      background:#fff;
-      border-radius:.85rem;
-      padding:.75rem 1rem;
-      box-shadow:0 10px 26px rgba(15,23,42,0.08);
+      background:#f8fafc;
+      border-radius:.75rem;
+      padding:.65rem .9rem;
       border:1px solid rgba(148,163,184,0.16);
-      max-width:720px;
-      margin:0 auto;
+      max-width:100%;
+      margin:0;
     }
     .practice-dashboard__chart-caption:empty{ display:none; }
-    .practice-dashboard__chart-actions{ display:flex; flex-direction:column; align-items:flex-start; gap:1rem; padding-top:.25rem; }
-    .practice-dashboard__chart-controls{ display:flex; flex-direction:column; gap:.65rem; align-items:flex-start; width:100%; }
+    .practice-dashboard__chart-actions{ display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:1.1rem; padding-top:.2rem; }
+    .practice-dashboard__chart-controls{ display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
     .practice-dashboard__view-toggle{
       display:inline-flex;
       align-items:center;
@@ -684,38 +676,38 @@
     .practice-dashboard__filter-select:focus-visible{ outline:3px solid var(--accent-200); outline-offset:1px; border-color:var(--accent-400); }
     .practice-dashboard__table-wrapper{
       border-radius:1rem;
-      border:1px solid rgba(148,163,184,0.18);
+      border:1px solid rgba(148,163,184,0.16);
       background:#fff;
       overflow:auto;
-      box-shadow:0 12px 28px rgba(15,23,42,0.08);
+      box-shadow:none;
       scrollbar-color:#94a3b8 rgba(226,232,240,0.65);
     }
     .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:10px; }
     .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.45); border-radius:999px; }
-    .practice-dashboard__matrix{ width:100%; border-collapse:collapse; min-width:640px; }
-    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:var(--dashboard-header-bg); padding:.75rem 1rem; text-align:left; font-size:.72rem; text-transform:uppercase; letter-spacing:.08em; color:#64748b; border-bottom:1px solid rgba(148,163,184,0.2); z-index:2; }
-    .practice-dashboard__matrix-head-consigne{ min-width:220px; }
-    .practice-dashboard__matrix-consigne{ background:#fff; padding:.85rem 1rem; font-weight:600; color:#0f172a; text-align:left; }
+    .practice-dashboard__matrix{ width:100%; border-collapse:collapse; table-layout:fixed; min-width:0; }
+    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:var(--dashboard-header-bg); padding:.65rem .85rem; text-align:left; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:#64748b; border-bottom:1px solid rgba(148,163,184,0.2); z-index:2; }
+    .practice-dashboard__matrix-head-consigne{ width:26%; }
+    .practice-dashboard__matrix-consigne{ background:#fff; padding:.75rem .85rem; font-weight:600; color:#0f172a; text-align:left; }
     .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
     .practice-dashboard__consigne-name{ font-size:.98rem; }
-    .practice-dashboard__matrix tbody td{ padding:.45rem 0; text-align:center; }
+    .practice-dashboard__matrix tbody td{ padding:.4rem 0; text-align:center; }
     .practice-dashboard__matrix tbody tr:nth-child(even){ background:rgba(148,163,184,0.08); }
     .practice-dashboard__cell{
       position:relative;
       width:100%;
-      min-width:3.5rem;
-      padding:.65rem .5rem;
+      min-width:2.75rem;
+      padding:.55rem .45rem;
       border-radius:.6rem;
       border:1px solid transparent;
       font-weight:600;
-      font-size:.88rem;
+      font-size:.85rem;
       background:transparent;
       color:#0f172a;
       display:flex;
       align-items:center;
       justify-content:center;
       font-variant-numeric:tabular-nums;
-      line-height:1.4;
+      line-height:1.35;
     }
     .practice-dashboard__cell--ok{ background:var(--dashboard-status-ok); color:var(--dashboard-status-ok-text); border-color:rgba(16,185,129,0.25); }
     .practice-dashboard__cell--mid{ background:var(--dashboard-status-mid); color:var(--dashboard-status-mid-text); border-color:rgba(234,179,8,0.25); }
@@ -732,12 +724,9 @@
     .practice-dashboard__empty{ padding:1.5rem; border-radius:1rem; border:1px dashed rgba(148,163,184,0.35); background:#f8fafc; font-size:.9rem; color:#475569; text-align:center; }
     .practice-dashboard__empty-row{ padding:2rem 1rem; text-align:center; font-size:.9rem; color:#94A3B8; }
     .practice-dashboard__footer{
-      margin-top:auto;
-      padding:1rem clamp(1rem,2.8vw,1.4rem);
-      border-radius:1.1rem;
-      border:1px solid rgba(148,163,184,0.2);
+      padding:1.15rem clamp(1.5rem,3vw,2.25rem);
+      border-top:1px solid rgba(148,163,184,0.16);
       background:#fff;
-      box-shadow:0 -12px 30px rgba(15,23,42,0.08);
       display:flex;
       align-items:center;
       justify-content:flex-end;
@@ -767,8 +756,10 @@
     }
     @media (max-width: 768px){
       .practice-dashboard.goal-modal{ padding:0; align-items:stretch; }
-      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:none; border:0; padding:1.4rem clamp(1rem,4vw,1.6rem) 1.8rem; }
-      .practice-dashboard.goal-modal .practice-dashboard__card{ padding-top:calc(env(safe-area-inset-top,0) + 1.4rem); }
+      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:none; border:0; }
+      .practice-dashboard.goal-modal .practice-dashboard__header{ padding:calc(env(safe-area-inset-top,0) + 1.4rem) clamp(1rem,4vw,1.6rem) 1rem; }
+      .practice-dashboard.goal-modal .practice-dashboard__body{ padding:1.4rem clamp(1rem,4vw,1.6rem); }
+      .practice-dashboard.goal-modal .practice-dashboard__footer{ padding:1.2rem clamp(1rem,4vw,1.6rem); }
       .practice-dashboard__view-toggle{ width:100%; justify-content:space-between; }
       .practice-dashboard__view-btn{ flex:1 1 auto; text-align:center; }
       .practice-dashboard__filter-select{ width:100%; }


### PR DESCRIPTION
## Summary
- rebuild the practice dashboard modal container so the header, content and footer share a single opaque card with consistent spacing
- tighten typography and hierarchy for headings and sections to improve readability without the "zoomed" appearance
- resize chart and table surfaces to fit within the popup, removing forced horizontal scrolling while keeping mobile-safe spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a6c62db08333adf58d746bf22ac0