### PR TITLE
Remove admin notifications UI and email daily summary

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -349,29 +349,6 @@ async function disablePushToken(db, uid, token) {
   }, { merge: true });
 }
 
-async function saveAdminPushToken(db, token, extra = {}) {
-  if (!db || !token) return;
-  const ref = doc(collection(db, "adminPushTokens"), token);
-  await setDoc(ref, {
-    token,
-    enabled: true,
-    ua: navigator.userAgent || "",
-    platform: navigator.platform || "",
-    updatedAt: serverTimestamp(),
-    createdAt: serverTimestamp(),
-    ...extra,
-  }, { merge: true });
-}
-
-async function disableAdminPushToken(db, token) {
-  if (!db || !token) return;
-  const ref = doc(collection(db, "adminPushTokens"), token);
-  await setDoc(ref, {
-    enabled: false,
-    updatedAt: serverTimestamp(),
-  }, { merge: true });
-}
-
 // score pour likert -> 0 / 0.5 / 1
 function likertScore(v) {
   return ({ yes: 1, rather_yes: 0.5, medium: 0, rather_no: 0, no: 0, no_answer: 0 })[v] ?? 0;
@@ -1003,8 +980,6 @@ Object.assign(Schema, {
   upsertSRState,
   savePushToken,
   disablePushToken,
-  saveAdminPushToken,
-  disableAdminPushToken,
   likertScore,
   nextCooldownAfterAnswer,
   resetSRForConsigne,


### PR DESCRIPTION
## Summary
- remove the admin notification toggles from the web UI and simplify related event handling
- drop admin push token helpers from the shared schema now that the admin UI no longer exposes them
- enhance the daily reminder cloud function to track per-user delivery results and email an SMTP summary report

## Testing
- not run (tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d649b9b12083339fbf9ad7f6f4034e