### PR TITLE
Improve iOS onboarding for notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,14 @@
           }
 
           if (isiOS && !isStandalone) {
-            alert("Pour ajouter cette app à l’écran d’accueil, ouvre le menu de partage Safari puis choisis « Ajouter à l’écran d’accueil ».");
+            const message = [
+              "Pour installer l’app sur iPhone/iPad :",
+              "1. Ouvre cette page dans Safari.",
+              "2. Appuie sur le bouton « Partager » (carré avec une flèche).",
+              "3. Choisis « Ajouter à l’écran d’accueil ».",
+              "4. Valide avec « Ajouter », puis lance l’app depuis la nouvelle icône.",
+            ].join("\n");
+            alert(message);
             return;
           }
 


### PR DESCRIPTION
## Summary
- add iOS and standalone detection helpers to guard push activation
- show detailed guidance on iOS when enabling notifications outside standalone mode
- expand iOS installation alert with step-by-step Safari instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6583b83848333b0a6ee87f3cec590