### PR TITLE
Prioritize profile.name in Cloud Function first-name extraction

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -617,7 +617,7 @@ function pluralize(count, singular, plural = null) {
 }
 
 function extractFirstName(profile = {}) {
-  const raw = String(profile.displayName || profile.name || "").trim();
+  const raw = String(profile.name || profile.displayName || "").trim();
   if (!raw) return "";
   const parts = raw.split(/\s+/).filter(Boolean);
   if (!parts.length) return "";


### PR DESCRIPTION
## Summary
- update the Cloud Function helper to read `profile.name` before `profile.displayName`
- keep first-name extraction aligned with the field ordering used by the client schema

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65f824a4c8333b400424a6f7190a5