### PR TITLE
Simplify dashboards to minimal history view

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,285 +526,90 @@
     .goal-linker__history[hidden]{ display:none; }
 
 
-    .practice-dashboard{
-      --dashboard-surface:#ffffff;
-      --dashboard-border:rgba(15,23,42,0.08);
-      --dashboard-shadow:0 22px 48px rgba(15,23,42,0.12);
-      --dashboard-header-bg:#f8fafc;
-      --dashboard-grid-stripe:rgba(148,163,184,0.05);
-      --dashboard-status-ok:rgba(34,197,94,0.08);
-      --dashboard-status-ok-text:#166534;
-      --dashboard-status-mid:rgba(234,179,8,0.12);
-      --dashboard-status-mid-text:#b45309;
-      --dashboard-status-ko:rgba(239,68,68,0.1);
-      --dashboard-status-ko-text:#b91c1c;
-      --dashboard-status-na:rgba(148,163,184,0.1);
-      --dashboard-status-na-text:#475569;
-    }
-    .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(1.25rem,3.5vw,3.5rem); }
+    .practice-dashboard.goal-modal{ display:flex; align-items:center; justify-content:center; padding:clamp(1.5rem,4vw,3rem); }
     .practice-dashboard.goal-modal .modal-card{ padding:0; background:transparent; box-shadow:none; border:0; }
     .practice-dashboard__card{
-      position:relative;
-      width:min(1340px,96vw);
-      max-height:min(96vh,1000px);
-      display:grid;
-      grid-template-rows:auto 1fr auto;
-      gap:0;
-      padding:0;
+      width:min(720px,94vw);
+      max-height:90vh;
       background:#fff;
-      border-radius:1.5rem;
-      border:1px solid rgba(15,23,42,0.08);
-      box-shadow:0 20px 44px rgba(15,23,42,0.14);
+      border-radius:1.2rem;
+      border:1px solid rgba(148,163,184,0.2);
+      box-shadow:0 18px 36px rgba(15,23,42,0.16);
+      display:flex;
+      flex-direction:column;
       overflow:hidden;
     }
     .practice-dashboard__header{
+      padding:1.5rem clamp(1.4rem,4vw,2rem) 1.1rem;
       display:flex;
-      flex-wrap:wrap;
-      align-items:flex-end;
-      justify-content:space-between;
-      gap:1.75rem;
-      padding:clamp(1.6rem,2.8vw,2.1rem) clamp(1.6rem,3vw,2.4rem) clamp(1.2rem,2.4vw,1.6rem);
+      flex-direction:column;
+      gap:.75rem;
+      border-bottom:1px solid rgba(148,163,184,0.2);
       background:#fff;
-      border-bottom:1px solid rgba(148,163,184,0.16);
     }
-    .practice-dashboard__title-group{ display:flex; flex-direction:column; gap:.45rem; max-width:min(560px,100%); flex:1 1 320px; }
-    .practice-dashboard__context{ display:inline-flex; align-items:center; gap:.35rem; padding:.4rem .85rem; border-radius:999px; background:rgba(59,130,246,0.08); color:#1d4ed8; font-size:.75rem; font-weight:600; letter-spacing:.14em; text-transform:uppercase; width:max-content; }
-    .practice-dashboard__title{ font-size:2rem; font-weight:700; color:#0f172a; letter-spacing:-.025em; margin:0; line-height:1.15; }
-    .practice-dashboard__subtitle{ font-size:.95rem; color:#5b6b83; line-height:1.65; max-width:620px; margin:0; font-weight:500; }
-    .practice-dashboard__header-actions{
-      display:flex;
-      align-items:center;
-      gap:1rem;
-      flex-wrap:wrap;
-      justify-content:flex-end;
-      min-width:260px;
-    }
-    .practice-dashboard__close{ border-color:transparent; background:#e2e8f0; color:#0f172a; transition:background .15s ease; }
-    .practice-dashboard__close:hover{ background:#cbd5f5; }
+    .practice-dashboard__title-group{ display:flex; flex-direction:column; gap:.45rem; }
+    .practice-dashboard__context{ display:inline-flex; align-items:center; gap:.4rem; padding:.35rem .75rem; border-radius:999px; background:rgba(62,166,235,0.12); color:#0f4c75; font-size:.7rem; font-weight:600; text-transform:uppercase; letter-spacing:.12em; width:max-content; }
+    .practice-dashboard__title{ margin:0; font-size:1.6rem; line-height:1.2; font-weight:700; color:#0f172a; }
+    .practice-dashboard__subtitle{ margin:0; font-size:.9rem; color:#475569; line-height:1.5; }
+    .practice-dashboard__close{ align-self:flex-end; border:1px solid rgba(148,163,184,0.4); background:#f1f5f9; color:#0f172a; border-radius:.75rem; padding:.45rem .8rem; cursor:pointer; transition:background .15s ease,border-color .15s ease; }
+    .practice-dashboard__close:hover{ background:#e2e8f0; border-color:rgba(148,163,184,0.6); }
     .practice-dashboard__close:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
     .practice-dashboard__body{
+      flex:1;
       overflow-y:auto;
-      padding:clamp(1.65rem,2.8vw,2.25rem) clamp(1.65rem,3.2vw,2.6rem) clamp(1.5rem,2.5vw,2.15rem);
-      display:flex;
-      flex-direction:column;
-      gap:1.6rem;
+      padding:1.5rem clamp(1.4rem,4vw,2rem);
       background:#f8fafc;
-      min-height:0;
-    }
-    .practice-dashboard__section{
       display:flex;
       flex-direction:column;
-      gap:1.1rem;
-      background:#fff;
-      border-radius:1.25rem;
-      padding:clamp(1.2rem,2.2vw,1.75rem);
-      border:1px solid rgba(148,163,184,0.12);
-      box-shadow:0 10px 26px rgba(15,23,42,0.06);
+      gap:1.25rem;
     }
-    .practice-dashboard__section-head{ display:flex; align-items:flex-start; justify-content:space-between; gap:1.1rem; flex-wrap:wrap; }
-    .practice-dashboard__section-title{ font-weight:700; font-size:1.15rem; color:#0f172a; letter-spacing:-.015em; margin:0; }
-    .practice-dashboard__section-subtitle{ font-size:.83rem; color:#64748b; margin:0; }
-    .practice-dashboard__chart-panel{
+    .practice-dashboard__history{ display:flex; flex-direction:column; gap:1.2rem; }
+    .practice-dashboard__history-section{
+      background:#fff;
+      border:1px solid rgba(148,163,184,0.28);
+      border-radius:1rem;
+      padding:1.15rem;
       display:flex;
       flex-direction:column;
       gap:.75rem;
-      background:#fff;
-      border-radius:1rem;
-      padding:.85rem clamp(.85rem,1.8vw,1.2rem) 1rem;
-      border:1px solid rgba(148,163,184,0.12);
-      box-shadow:none;
+      box-shadow:0 12px 24px rgba(15,23,42,0.08);
     }
-    .practice-dashboard__chart-scroll{ border-radius:.85rem; overflow:hidden; padding:.35rem; background:#f8fafc; border:1px solid rgba(148,163,184,0.14); }
-    .practice-dashboard__chart-scroll:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
-    .practice-dashboard__chart-scroll.is-dragging{ cursor:grabbing; user-select:none; }
-    .practice-dashboard__chart-scroll::-webkit-scrollbar{ height:10px; }
-    .practice-dashboard__chart-scroll::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.4); border-radius:999px; }
-    .practice-dashboard__chart-card{
-      position:relative;
-      border:1px solid rgba(148,163,184,0.14);
+    .practice-dashboard__history-header{ display:flex; align-items:center; justify-content:space-between; }
+    .practice-dashboard__history-heading{ margin:0; font-size:1.05rem; font-weight:600; color:#0f172a; }
+    .practice-dashboard__history-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.6rem; }
+    .practice-dashboard__history-item{ margin:0; }
+    .practice-dashboard__history-entry{
+      width:100%;
+      border:1px solid rgba(148,163,184,0.35);
       border-radius:.9rem;
-      background:#fff;
-      padding:.85rem 1rem 1.05rem;
-      min-height:140px;
-      box-shadow:none;
-    }
-    .practice-dashboard__chart-canvas{
-      position:relative;
-      min-height:140px;
-      width:100%;
-      min-width:0;
-      margin:0;
-      padding:.35rem;
-      background:#fff;
-      border-radius:.75rem;
-      box-shadow:inset 0 0 0 1px rgba(148,163,184,0.12);
-    }
-    .practice-dashboard__chart-card canvas{
-      width:100%;
-      height:100%;
-      display:block;
-      background:#fff;
-      border-radius:.75rem;
-    }
-    .practice-dashboard__chart-caption{
-      font-size:.8rem;
-      color:#475569;
-      background:#f8fafc;
-      border-radius:.75rem;
-      padding:.55rem .85rem;
-      border:1px solid rgba(148,163,184,0.14);
-      max-width:100%;
-      margin:0;
-    }
-    .practice-dashboard__chart-caption:empty{ display:none; }
-    .practice-dashboard__chart-actions{ display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:1.1rem; padding-top:.2rem; }
-    .practice-dashboard__chart-controls{ display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
-    .practice-dashboard__view-toggle{
-      display:inline-flex;
-      align-items:center;
-      gap:.35rem;
-      padding:.4rem;
-      border-radius:.9rem;
-      background:#fff;
-      box-shadow:0 8px 18px rgba(15,23,42,0.07);
-      border:1px solid rgba(148,163,184,0.18);
-    }
-    .practice-dashboard__view-btn{ border:0; background:transparent; padding:.5rem 1.1rem; border-radius:.75rem; font-size:.82rem; font-weight:600; color:#1f2937; cursor:pointer; transition:background .15s ease,color .15s ease,box-shadow .15s ease; }
-    .practice-dashboard__view-btn:hover:not(:disabled){ background:rgba(148,163,184,0.14); }
-    .practice-dashboard__view-btn.is-active{ background:var(--accent-600); color:#fff; box-shadow:0 6px 18px rgba(59,130,246,0.35); }
-    .practice-dashboard__view-btn:disabled{ opacity:.55; cursor:default; }
-    .practice-dashboard__view-btn:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
-    .practice-dashboard__filter{ display:flex; flex-direction:column; gap:.3rem; font-size:.78rem; color:#475569; }
-    .practice-dashboard__filter-label{ font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:#0f172a; }
-    .practice-dashboard__filter-select{ border:1px solid rgba(148,163,184,0.32); border-radius:.8rem; padding:.45rem .75rem; font-size:.9rem; color:#0f172a; background:#fff; box-shadow:0 8px 18px rgba(15,23,42,0.05); }
-    .practice-dashboard__filter-select:focus-visible{ outline:3px solid var(--accent-200); outline-offset:1px; border-color:var(--accent-400); }
-    .practice-dashboard__filter--inline{ min-width:0; }
-    .practice-dashboard__filter--inline .practice-dashboard__filter-select{ min-width:9.5rem; }
-    .practice-dashboard__table-wrapper{
-      position:relative;
-      margin:0;
-      padding:.4rem .45rem .6rem;
-      border-radius:1rem;
-      border:1px solid rgba(148,163,184,0.22);
-      background:var(--dashboard-surface);
-      overflow:auto;
-      box-shadow:0 8px 20px rgba(15,23,42,0.06);
-      scrollbar-color:#94a3b8 rgba(226,232,240,0.6);
-    }
-    .practice-dashboard__table-wrapper::-webkit-scrollbar{ height:10px; }
-    .practice-dashboard__table-wrapper::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.42); border-radius:999px; }
-    .practice-dashboard__matrix{ width:100%; border-collapse:separate; border-spacing:0; table-layout:fixed; min-width:640px; }
-    .practice-dashboard__matrix thead th{ position:sticky; top:0; background:var(--dashboard-header-bg); padding:.6rem .85rem; text-align:center; font-size:.72rem; font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:#475569; border-bottom:1px solid rgba(148,163,184,0.2); z-index:2; white-space:nowrap; }
-    .practice-dashboard__matrix thead th > span{ display:block; }
-    .practice-dashboard__matrix-head-consigne{ width:220px; min-width:220px; max-width:320px; left:0; z-index:3; text-align:left; box-shadow:2px 0 0 rgba(148,163,184,0.12); }
-    .practice-dashboard__matrix thead th.practice-dashboard__matrix-head-consigne{ position:sticky; background:var(--dashboard-header-bg); }
-    .practice-dashboard__matrix-consigne{ position:sticky; left:0; background:#fff; padding:.9rem 1.1rem; font-weight:600; color:#0f172a; text-align:left; border-right:1px solid rgba(148,163,184,0.16); z-index:2; box-shadow:2px 0 0 rgba(148,163,184,0.08); display:flex; flex-direction:column; gap:.45rem; min-width:220px; max-width:320px; line-height:1.35; }
-    .practice-dashboard__row-meta{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
-    .practice-dashboard__consigne-name{ font-size:.93rem; font-weight:600; line-height:1.4; word-break:break-word; }
-    .practice-dashboard__matrix tbody tr{ position:relative; border-bottom:1px solid rgba(148,163,184,0.16); }
-    .practice-dashboard__matrix tbody tr:last-child{ border-bottom:none; }
-    .practice-dashboard__matrix tbody tr::before{ display:none; }
-    .practice-dashboard__matrix tbody td{ position:relative; z-index:1; padding:.5rem .45rem; text-align:center; background:#fff; vertical-align:middle; }
-    .practice-dashboard__matrix tbody td:last-child{ padding-right:.75rem; }
-    .practice-dashboard__cell{
-      position:relative;
-      width:100%;
-      min-width:3rem;
-      padding:.45rem .6rem;
-      border-radius:.6rem;
-      border:1px solid transparent;
-      font-weight:600;
-      font-size:.85rem;
-      background:rgba(148,163,184,0.06);
-      color:#0f172a;
+      background:#f9fafb;
       display:flex;
-      align-items:center;
-      justify-content:center;
-      font-variant-numeric:tabular-nums;
-      line-height:1.3;
-      transition:transform .12s ease, box-shadow .12s ease, background .12s ease;
+      flex-direction:column;
+      gap:.4rem;
+      padding:.8rem 1rem;
+      font:inherit;
+      color:inherit;
+      text-align:left;
       cursor:pointer;
+      transition:background .15s ease,border-color .15s ease,box-shadow .15s ease;
     }
-    .practice-dashboard__cell:hover{ transform:translateY(-1px); box-shadow:0 6px 14px rgba(15,23,42,0.08); }
-    .practice-dashboard__cell--ok{ background:var(--dashboard-status-ok); color:var(--dashboard-status-ok-text); border-color:rgba(34,197,94,0.18); }
-    .practice-dashboard__cell--mid{ background:var(--dashboard-status-mid); color:var(--dashboard-status-mid-text); border-color:rgba(234,179,8,0.18); }
-    .practice-dashboard__cell--ko{ background:var(--dashboard-status-ko); color:var(--dashboard-status-ko-text); border-color:rgba(239,68,68,0.16); }
-    .practice-dashboard__cell--na{ background:var(--dashboard-status-na); color:var(--dashboard-status-na-text); border-color:rgba(148,163,184,0.2); }
-    .practice-dashboard__cell--empty{ font-weight:500; color:#94a3b8; background:transparent; border-color:rgba(148,163,184,0.24); }
-    .practice-dashboard__cell[data-has-note="1"]::after{ content:""; position:absolute; top:6px; right:6px; width:7px; height:7px; border-radius:999px; background:#38bdf8; }
-    .practice-dashboard__cell:focus-visible{ outline:3px solid var(--accent-200); outline-offset:2px; }
-    .practice-dashboard__hint{ font-size:.78rem; color:#64748b; text-align:right; margin-top:.75rem; }
-    .practice-dashboard__chart-option{ display:flex; align-items:center; gap:.55rem; padding:.35rem .75rem; border-radius:.75rem; background:#f8fafc; border:1px solid rgba(148,163,184,0.35); font-size:.85rem; color:#1f2937; width:100%; transition:background .15s ease,border-color .15s ease,box-shadow .15s ease; }
-    .practice-dashboard__chart-option:hover{ background:#e2e8f0; border-color:rgba(148,163,184,0.55); box-shadow:0 4px 12px rgba(15,23,42,0.08); }
-    .practice-dashboard__chart-option input{ accent-color:var(--accent-600); }
-    .practice-dashboard__chart-empty{ font-size:.85rem; color:#64748b; }
-    .practice-dashboard__empty{ padding:1.5rem; border-radius:1rem; border:1px dashed rgba(148,163,184,0.35); background:#f8fafc; font-size:.9rem; color:#475569; text-align:center; }
-    .practice-dashboard__empty-row{ padding:2rem 1rem; text-align:center; font-size:.9rem; color:#94A3B8; }
-    .practice-dashboard__footer{
-      padding:1.15rem clamp(1.5rem,3vw,2.25rem);
-      border-top:1px solid rgba(148,163,184,0.16);
-      background:#fff;
-      display:flex;
-      align-items:center;
-      justify-content:flex-end;
-      gap:.75rem;
-      position:sticky;
-      bottom:0;
-      z-index:2;
-    }
-    .practice-dashboard__footer-actions{ display:flex; gap:.6rem; align-items:center; }
-    .practice-dashboard__save-button{
-      background:#22c55e;
-      color:#fff;
-      border:none;
-      padding:.65rem 1.4rem;
-      border-radius:.9rem;
-      font-weight:600;
-      box-shadow:0 14px 30px rgba(34,197,94,0.35);
-      transition:background .15s ease, box-shadow .15s ease;
-    }
-    .practice-dashboard__save-button:hover{ background:#16a34a; box-shadow:0 10px 26px rgba(22,163,74,0.32); }
-    .practice-dashboard__save-button:focus-visible{ outline:3px solid rgba(34,197,94,0.35); outline-offset:2px; }
-    @media (max-width: 1024px){
-      .practice-dashboard__card{ width:min(100%,calc(100vw - 1.5rem)); }
-      .practice-dashboard__body{ padding-right:0; margin-right:0; gap:1.5rem; }
-      .practice-dashboard__header{ flex-direction:column; align-items:flex-start; gap:1.15rem; padding:1.25rem clamp(1rem,3vw,1.45rem); }
-      .practice-dashboard__header-actions{ width:100%; justify-content:flex-start; padding:0; min-width:0; }
-    }
-    @media (max-width: 768px){
-      .practice-dashboard.goal-modal{ padding:0; align-items:stretch; }
-      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; min-height:100dvh; border-radius:0; box-shadow:none; border:0; }
-      .practice-dashboard.goal-modal .practice-dashboard__header{ padding:calc(env(safe-area-inset-top,0) + 1.4rem) clamp(1rem,4vw,1.6rem) 1rem; }
-      .practice-dashboard.goal-modal .practice-dashboard__body{ padding:1.4rem clamp(1rem,4vw,1.6rem); }
-      .practice-dashboard.goal-modal .practice-dashboard__footer{ padding:1.2rem clamp(1rem,4vw,1.6rem); }
-      .practice-dashboard__view-toggle{ width:100%; justify-content:space-between; }
-      .practice-dashboard__view-btn{ flex:1 1 auto; text-align:center; }
-      .practice-dashboard__filter-select{ width:100%; }
-      .practice-dashboard__chart-card{ min-height:150px; padding:1rem 1.1rem 1.2rem; }
-      .practice-dashboard__chart-canvas{ min-width:min(520px,100%); min-height:140px; }
-        .practice-dashboard__chart-actions{ flex-direction:column; align-items:stretch; gap:.75rem; }
-        .practice-dashboard__chart-controls{ justify-content:flex-start; }
-      .practice-dashboard__table-wrapper{ box-shadow:0 10px 24px rgba(15,23,42,0.08); padding:0; }
-      .practice-dashboard__hint{ text-align:left; }
-      .practice-dashboard__footer{ flex-direction:column; align-items:stretch; gap:.65rem; }
-      .practice-dashboard__footer-actions{ justify-content:flex-end; }
-    }
+    .practice-dashboard__history-entry:hover{ background:#eef2ff; border-color:rgba(99,102,241,0.45); box-shadow:0 10px 20px rgba(99,102,241,0.18); }
+    .practice-dashboard__history-entry:focus-visible{ outline:3px solid rgba(99,102,241,0.35); outline-offset:2px; }
+    .practice-dashboard__history-date{ display:flex; flex-wrap:wrap; gap:.4rem; align-items:baseline; font-size:.82rem; color:#64748b; }
+    .practice-dashboard__history-date-main{ font-weight:600; color:#0f172a; }
+    .practice-dashboard__history-date-sub{ font-size:.78rem; color:#94a3b8; }
+    .practice-dashboard__history-value{ font-size:1rem; font-weight:600; color:#0f172a; }
+    .practice-dashboard__history-note{ font-size:.9rem; color:#475569; display:block; }
+    .practice-dashboard__empty{ padding:1rem; border-radius:.9rem; border:1px dashed rgba(148,163,184,0.5); background:#f8fafc; font-size:.9rem; color:#64748b; text-align:center; }
+    .practice-dashboard__footer{ padding:1rem clamp(1.4rem,4vw,2rem); border-top:1px solid rgba(148,163,184,0.2); background:#fff; display:flex; justify-content:flex-end; }
+    .practice-dashboard__footer-actions{ display:flex; gap:.75rem; }
     @media (max-width: 640px){
-      .practice-dashboard__title{ font-size:1.25rem; }
-      .practice-dashboard__section-title{ font-size:1rem; }
-      .practice-dashboard__subtitle{ font-size:.9rem; }
-      .practice-dashboard__section{ padding:1.35rem clamp(1rem,4vw,1.6rem); }
-      .practice-dashboard__chart-scroll{ padding:.6rem; }
-      .practice-dashboard__matrix{ min-width:0; border-spacing:0; }
-      .practice-dashboard__matrix thead{ display:none; }
-      .practice-dashboard__matrix tbody{ display:flex; flex-direction:column; gap:1rem; }
-      .practice-dashboard__matrix tbody tr{ display:flex; flex-direction:column; gap:.85rem; padding:1rem clamp(.75rem,4vw,1.25rem); border-radius:1rem; background:#fff; box-shadow:0 12px 28px rgba(15,23,42,0.08); border:1px solid rgba(148,163,184,0.2); border-bottom:0; }
-      .practice-dashboard__matrix tbody tr::before{ display:none; }
-      .practice-dashboard__matrix-consigne{ padding:0; border:0; box-shadow:none; }
-      .practice-dashboard__matrix tbody td{ padding:0; text-align:left; }
-      .practice-dashboard__cell{ width:100%; min-width:0; justify-content:flex-start; align-items:flex-start; gap:.4rem; text-align:left; font-size:.95rem; padding:.65rem .7rem; }
-      .practice-dashboard__cell::before{ content:attr(data-label); font-size:.7rem; font-weight:600; letter-spacing:.08em; text-transform:uppercase; color:#94a3b8; }
-      .practice-dashboard__hint{ margin-top:-.15rem; }
+      .practice-dashboard.goal-modal{ padding:0; align-items:stretch; }
+      .practice-dashboard.goal-modal .practice-dashboard__card{ width:100%; max-height:100dvh; border-radius:0; box-shadow:none; border:0; }
+      .practice-dashboard.goal-modal .practice-dashboard__header{ padding:calc(env(safe-area-inset-top,0) + 1.25rem) 1.1rem 1rem; }
+      .practice-dashboard.goal-modal .practice-dashboard__body{ padding:1.1rem; }
+      .practice-dashboard.goal-modal .practice-dashboard__footer{ padding:1rem 1.1rem; }
+      .practice-dashboard__history-entry{ padding:.75rem .9rem; }
     }
     .practice-editor{ display:flex; flex-direction:column; gap:1rem; }
     .practice-editor__header{ display:flex; flex-direction:column; gap:.25rem; }

--- a/modes.js
+++ b/modes.js
@@ -815,39 +815,6 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
       : effectiveCategory
       ? `Journalier — ${effectiveCategory}`
       : "Journalier — toutes les catégories";
-    const categoryFilterMarkup =
-      !providedConsignes && isDaily && dailyCategories.length > 1
-        ? `<label class="practice-dashboard__filter"><span class="practice-dashboard__filter-label">Catégorie</span><select class="practice-dashboard__filter-select" data-category-select><option value="__all__"${effectiveCategory ? "" : " selected"}>Toutes les catégories</option>${dailyCategories
-            .map(
-              (name) =>
-                `<option value="${escapeHtml(name)}"${name === effectiveCategory ? " selected" : ""}>${escapeHtml(name)}</option>`,
-            )
-            .join("")}</select></label>`
-        : "";
-
-    const trendTitle = customTrendTitle
-      ? customTrendTitle
-      : providedConsignes
-      ? "Progression des consignes liées"
-      : isPractice
-      ? "Tendance des itérations"
-      : "Tendance des jours";
-    const detailsTitle = customDetailsTitle
-      ? customDetailsTitle
-      : providedConsignes
-      ? "Historique par consigne"
-      : isPractice
-      ? "Détails par consigne"
-      : "Détails du journal";
-    const chartScrollLabel = providedConsignes
-      ? "Défilement horizontal du graphique des consignes liées"
-      : isPractice
-      ? "Défilement horizontal du graphique des itérations"
-      : "Défilement horizontal du graphique des jours";
-    const tableHintText = isPractice
-      ? "Cliquez sur une cellule pour ajouter ou modifier la note correspondante."
-      : "Cliquez sur une cellule pour mettre à jour la valeur du jour sélectionné.";
-
     const headerMainTitle = providedConsignes
       ? "Progression"
       : isPractice
@@ -874,91 +841,29 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
     })();
     const safeHeaderContext = escapeHtml(headerContextText);
 
-    const chartSubtitleText = providedConsignes
-      ? "Comparez les consignes liées et leur évolution."
+    const historySubtitleText = providedConsignes
+      ? "Historique des consignes sélectionnées."
       : isPractice
-      ? "Visualisez la progression de vos sessions récentes."
-      : "Suivez l’évolution de vos journées au fil du temps.";
-
-    const viewToggleMarkup = `
-      <div class="practice-dashboard__view-toggle" data-view-toggle role="tablist" aria-label="Changer la vue">
-        <button type="button" class="practice-dashboard__view-btn is-active" data-view="chart" role="tab" aria-selected="true">Vue graphique</button>
-        <button type="button" class="practice-dashboard__view-btn" data-view="table" role="tab" aria-selected="false" tabindex="-1">Vue tableau</button>
-      </div>`;
-
-    const rangeOptions = [5, 10, 15, 20];
-    const rangeFilterMarkup = iterationMeta.length > 1
-      ? `<label class="practice-dashboard__filter practice-dashboard__filter--inline"><span class="practice-dashboard__filter-label">Période</span><select class="practice-dashboard__filter-select" data-range-select>` +
-        `${rangeOptions
-          .map((value) => {
-            const disabled = iterationMeta.length < value ? " disabled" : "";
-            const selected = currentWindowSize === value ? " selected" : "";
-            const suffix = value > 1 ? "dernières itérations" : "dernière itération";
-            return `<option value="${value}"${disabled}${selected}>${value} ${suffix}</option>`;
-          })
-          .join("")}` +
-        `<option value="__all__"${currentWindowSize == null ? " selected" : ""}>Tout l’historique</option></select></label>`
-      : "";
+      ? "Historique des sessions de pratique, du plus récent au plus ancien."
+      : "Historique quotidien classé par entrée, du plus récent au plus ancien.";
 
     const html = `
-      <div class="goal-modal modal practice-dashboard">
+      <div class="goal-modal modal practice-dashboard practice-dashboard--minimal">
         <div class="goal-modal-card modal-card practice-dashboard__card">
           <div class="practice-dashboard__header">
             <div class="practice-dashboard__title-group">
               <span class="practice-dashboard__context">${safeHeaderContext}</span>
               <h2 class="practice-dashboard__title">${escapeHtml(headerMainTitle)}</h2>
-              <p class="practice-dashboard__subtitle">${escapeHtml(headerSubtitle)}</p>
+              <p class="practice-dashboard__subtitle">${escapeHtml(historySubtitleText)}</p>
             </div>
-            <div class="practice-dashboard__header-actions">
-              ${viewToggleMarkup}
-              ${rangeFilterMarkup}
-              ${categoryFilterMarkup}
-              <button type="button" class="practice-dashboard__close btn btn-ghost" data-close aria-label="Fermer">✕</button>
-            </div>
+            <button type="button" class="practice-dashboard__close btn btn-ghost" data-close aria-label="Fermer">✕</button>
           </div>
           <div class="practice-dashboard__body">
-            <section class="practice-dashboard__section practice-dashboard__section--chart">
-              <div class="practice-dashboard__section-head">
-                <div>
-                  <h3 class="practice-dashboard__section-title">${escapeHtml(trendTitle)}</h3>
-                  <p class="practice-dashboard__section-subtitle">${escapeHtml(chartSubtitleText)}</p>
-                </div>
-              </div>
-              <div class="practice-dashboard__chart-panel">
-                <div class="practice-dashboard__chart-scroll" data-chart-scroll tabindex="0" aria-label="${escapeHtml(chartScrollLabel)}">
-                  <div class="practice-dashboard__chart-card" data-chart-card>
-                    <div class="practice-dashboard__chart-canvas" data-chart-canvas>
-                      <canvas id="practiceCatChart"></canvas>
-                    </div>
-                  </div>
-                </div>
-                <p class="practice-dashboard__chart-caption" data-chart-caption></p>
-              </div>
-              <div class="practice-dashboard__chart-actions">
-                <div class="practice-dashboard__chart-controls" data-chart-select></div>
-              </div>
-            </section>
-            <section class="practice-dashboard__section practice-dashboard__section--table">
-              <div class="practice-dashboard__section-head">
-                <h3 class="practice-dashboard__section-title">${escapeHtml(detailsTitle)}</h3>
-              </div>
-              <div class="practice-dashboard__table-wrapper">
-                <table class="practice-dashboard__matrix">
-                  <thead>
-                    <tr data-matrix-head>
-                      <th scope="col" class="practice-dashboard__matrix-head-consigne">Consigne</th>
-                    </tr>
-                  </thead>
-                  <tbody data-table-body></tbody>
-                </table>
-              </div>
-              <p class="practice-dashboard__hint">${escapeHtml(tableHintText)}</p>
-            </section>
+            <div class="practice-dashboard__history" data-history></div>
           </div>
           <footer class="practice-dashboard__footer">
             <div class="practice-dashboard__footer-actions">
-              <button type="button" class="btn btn-ghost" data-dismiss-dashboard>Annuler</button>
-              <button type="button" class="btn practice-dashboard__save-button" data-primary-action>Enregistrer</button>
+              <button type="button" class="btn btn-ghost" data-dismiss-dashboard>Fermer</button>
             </div>
           </footer>
         </div>
@@ -1019,6 +924,79 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
       button.addEventListener("click", close);
     });
     overlay.querySelector("[data-primary-action]")?.addEventListener("click", close);
+
+    const historyContainer = overlay.querySelector("[data-history]");
+
+    function renderHistory() {
+      if (!historyContainer) return;
+      if (!stats.length) {
+        historyContainer.innerHTML = '<p class="practice-dashboard__empty">Aucune consigne à afficher pour le moment.</p>';
+        return;
+      }
+      historyContainer.innerHTML = stats
+        .map((stat) => {
+          const items = (stat.entries || [])
+            .slice()
+            .reverse()
+            .map((entry) => {
+              const meta = iterationMetaByKey.get(entry.date) || null;
+              let pointIndex = Number.isInteger(meta?.index) ? meta.index : -1;
+              if (pointIndex === -1) {
+                pointIndex = stat.timeline.findIndex((point) => point.dateIso === entry.date);
+              }
+              if (pointIndex < 0) return "";
+              const dateLabel = meta?.fullLabel || meta?.label || entry.date;
+              const relativeLabel = formatRelativeDate(meta?.dateObj || entry.date);
+              const valueText = formatValue(stat.type, entry.value);
+              const normalizedValue = valueText == null ? "" : String(valueText).trim();
+              const safeValue = normalizedValue && normalizedValue !== "—" ? escapeHtml(normalizedValue) : "—";
+              const noteText = entry.note && entry.note.trim()
+                ? `<span class="practice-dashboard__history-note">${escapeHtml(entry.note)}</span>`
+                : "";
+              const relativeMarkup = relativeLabel
+                ? `<span class="practice-dashboard__history-date-sub">${escapeHtml(relativeLabel)}</span>`
+                : "";
+              return `
+                <li class="practice-dashboard__history-item">
+                  <button type="button" class="practice-dashboard__history-entry" data-entry data-consigne="${stat.id}" data-index="${pointIndex}">
+                    <span class="practice-dashboard__history-date">
+                      <span class="practice-dashboard__history-date-main">${escapeHtml(dateLabel)}</span>
+                      ${relativeMarkup}
+                    </span>
+                    <span class="practice-dashboard__history-value">${safeValue}</span>
+                    ${noteText}
+                  </button>
+                </li>
+              `;
+            })
+            .filter(Boolean);
+          const entriesMarkup = items.length
+            ? `<ol class="practice-dashboard__history-list">${items.join("")}</ol>`
+            : '<p class="practice-dashboard__empty">Aucune entrée enregistrée pour le moment.</p>';
+          return `
+            <section class="practice-dashboard__history-section" data-id="${stat.id}">
+              <header class="practice-dashboard__history-header">
+                <h3 class="practice-dashboard__history-heading">${escapeHtml(stat.name)}</h3>
+              </header>
+              ${entriesMarkup}
+            </section>
+          `;
+        })
+        .join("");
+    }
+
+    renderHistory();
+
+    historyContainer?.addEventListener("click", (event) => {
+      const target = event.target.closest("[data-entry]");
+      if (!target) return;
+      const consigneId = target.getAttribute("data-consigne");
+      const pointIndex = Number(target.getAttribute("data-index"));
+      if (!Number.isFinite(pointIndex)) return;
+      const stat = stats.find((item) => item.id === consigneId);
+      if (!stat) return;
+      openCellEditor(stat, pointIndex);
+    });
 
     const tableBody = overlay.querySelector("[data-table-body]");
     const headRow = overlay.querySelector("[data-matrix-head]");
@@ -1659,7 +1637,7 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
             await Schema.deleteHistoryEntry(ctx.db, ctx.user.uid, stat.id, point.dateIso);
             updateStatAfterEdit(stat, pointIndex, "", "");
             renderMatrix();
-            updateChartForStat(stat);
+            renderHistory();
             panel.remove();
           } catch (err) {
             console.error("practice-dashboard:clear-cell", err);
@@ -1688,7 +1666,7 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
             updateStatAfterEdit(stat, pointIndex, rawValue, note);
           }
           renderMatrix();
-          updateChartForStat(stat);
+          renderHistory();
           panel.remove();
         } catch (err) {
           console.error("practice-dashboard:save-cell", err);


### PR DESCRIPTION
## Summary
- replace the dashboard modal with a stripped-down history list layout
- render entries per consigne in a simple ordered list and hook into the existing editor
- trim the dashboard styling to match the new minimalist history-only design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d662ab0568833382210669b53c0d0e