### PR TITLE
Improve daily dashboard layout on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,19 @@
       text-transform:uppercase;
     }
 
+    /* Journalier — grille */
+    .daily-grid {
+      display:grid;
+      gap:1.75rem;
+    }
+    .daily-grid__item {
+      grid-column:1 / -1;
+    }
+    .daily-grid__actions {
+      display:flex;
+      justify-content:flex-end;
+    }
+
     /* Journalier — catégories */
     .daily-category {
       position:relative;
@@ -237,6 +250,8 @@
       border:1px solid rgba(148,163,184,.2);
       padding:1.5rem 1.75rem;
       box-shadow:0 14px 32px rgba(15,23,42,.06);
+      display:flex;
+      flex-direction:column;
     }
     .daily-category__header {
       display:flex;
@@ -274,6 +289,7 @@
     .daily-category__items {
       display:grid;
       gap:1.25rem;
+      flex:1 1 auto;
     }
     .daily-category__low {
       margin-top:.25rem;
@@ -393,6 +409,23 @@
       margin-left:1rem;
       border-color:rgba(148,163,184,.28);
       box-shadow:none;
+    }
+
+    @media (min-width: 1024px) {
+      .daily-grid {
+        grid-template-columns:repeat(2, minmax(0, 1fr));
+        align-items:start;
+        gap:2rem;
+      }
+      .daily-grid__item {
+        grid-column:auto;
+      }
+      .daily-grid__actions {
+        grid-column:1 / -1;
+      }
+      .daily-category {
+        height:100%;
+      }
     }
 
     .priority-surface {

--- a/modes.js
+++ b/modes.js
@@ -2502,19 +2502,19 @@ async function renderDaily(ctx, root, opts = {}) {
   };
 
   const form = document.createElement("form");
-  form.className = "grid gap-8";
+  form.className = "daily-grid";
   card.appendChild(form);
 
   if (!visible.length) {
     const empty = document.createElement("div");
-    empty.className = "rounded-xl border border-dashed border-gray-200 bg-white p-3 text-sm text-[var(--muted)]";
+    empty.className = "rounded-xl border border-dashed border-gray-200 bg-white p-3 text-sm text-[var(--muted)] daily-grid__item";
     empty.innerText = "Aucune consigne visible pour ce jour.";
     form.appendChild(empty);
   } else {
     categoryGroups.forEach(([cat, info]) => {
       const { groups, total } = info;
       const section = document.createElement("section");
-      section.className = "daily-category";
+      section.className = "daily-category daily-grid__item";
       section.innerHTML = `
         <div class="daily-category__header">
           <div class="daily-category__name">${escapeHtml(cat)}</div>
@@ -2575,7 +2575,7 @@ async function renderDaily(ctx, root, opts = {}) {
   }
 
   const actions = document.createElement("div");
-  actions.className = "flex justify-end";
+  actions.className = "flex justify-end daily-grid__item daily-grid__actions";
   actions.innerHTML = `<button type="submit" class="btn btn-primary">Enregistrer</button>`;
   form.appendChild(actions);
 


### PR DESCRIPTION
## Summary
- introduce a dedicated daily grid layout that assigns each category to a desktop column while keeping mobile display unchanged
- style the new grid with responsive CSS rules and ensure category cards stretch within their columns
- keep the submit action aligned across the grid and polish flex behaviour inside categories

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68d684873c28833384d83ce2de5ea7dd