### PR TITLE
Refine reminder notification body messaging

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const functions = require("firebase-functions");
 const admin = require("firebase-admin");
 const tls = require("tls");
+const { buildReminderBody } = require("./reminder");
 
 admin.initializeApp();
 
@@ -611,39 +612,12 @@ async function countObjectivesDueToday(uid, context) {
   return count;
 }
 
-function pluralize(count, singular, plural = null) {
-  if (count === 1) return singular;
-  return plural || `${singular}s`;
-}
-
 function extractFirstName(profile = {}) {
   const raw = String(profile.name || profile.displayName || "").trim();
   if (!raw) return "";
   const parts = raw.split(/\s+/).filter(Boolean);
   if (!parts.length) return "";
   return parts[0];
-}
-
-function buildReminderBody(firstName, consigneCount, objectiveCount) {
-  const prefix = firstName ? `${firstName}, ` : "";
-  const items = [];
-  if (consigneCount > 0) {
-    items.push(`${consigneCount} ${pluralize(consigneCount, "consigne")} à tracker`);
-  }
-  if (objectiveCount > 0) {
-    items.push(`${objectiveCount} ${pluralize(objectiveCount, "objectif")} à compléter`);
-  }
-  if (!items.length) {
-    return `${prefix}tu n’as rien à tracker aujourd’hui.`;
-  }
-  if (items.length === 1) {
-    return `${prefix}tu as ${items[0]} aujourd’hui.`;
-  }
-  if (items.length === 2) {
-    return `${prefix}tu as ${items[0]} et ${items[1]} aujourd’hui.`;
-  }
-  const last = items.pop();
-  return `${prefix}tu as ${items.join(", ")} et ${last} aujourd’hui.`;
 }
 
 async function collectPushTokens() {

--- a/functions/reminder.js
+++ b/functions/reminder.js
@@ -1,0 +1,16 @@
+function pluralize(count, singular, plural = null) {
+  if (count === 1) return singular;
+  return plural || `${singular}s`;
+}
+
+function buildReminderBody(firstName, consigneCount, objectiveCount) {
+  const prefix = firstName ? `${firstName}, ` : "";
+  if (consigneCount === 0 && objectiveCount === 0) {
+    return `${prefix}tu n’as rien à remplir aujourd’hui.`;
+  }
+  const consigneLabel = pluralize(consigneCount, "consigne");
+  const objectiveLabel = pluralize(objectiveCount, "objectif");
+  return `${prefix}tu as ${consigneCount} ${consigneLabel} et ${objectiveCount} ${objectiveLabel} à remplir aujourd’hui.`;
+}
+
+module.exports = { buildReminderBody };

--- a/tests/reminderBody.test.js
+++ b/tests/reminderBody.test.js
@@ -1,0 +1,41 @@
+const { buildReminderBody } = require("../functions/reminder");
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message} (attendu: ${expected}, obtenu: ${actual})`);
+  }
+}
+
+function runTests() {
+  assertEqual(
+    buildReminderBody("", 2, 3),
+    "tu as 2 consignes et 3 objectifs à remplir aujourd’hui.",
+    "Le message doit mentionner les compteurs au pluriel",
+  );
+
+  assertEqual(
+    buildReminderBody("Marie", 1, 1),
+    "Marie, tu as 1 consigne et 1 objectif à remplir aujourd’hui.",
+    "Le message doit gérer le singulier et le préfixe",
+  );
+
+  assertEqual(
+    buildReminderBody("", 0, 1),
+    "tu as 0 consignes et 1 objectif à remplir aujourd’hui.",
+    "Le message doit afficher zéro consigne explicitement",
+  );
+
+  assertEqual(
+    buildReminderBody("Paul", 0, 0),
+    "Paul, tu n’as rien à remplir aujourd’hui.",
+    "Le message de repli doit être utilisé lorsque tous les compteurs sont nuls",
+  );
+}
+
+try {
+  runTests();
+  console.log("All reminder body tests passed.");
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- ensure reminder bodies always mention both consigne and objectif counts with proper pluralization and fallback messaging
- move the reminder body builder into a dedicated helper module and wire it into the Cloud Function
- add unit coverage for the reminder body formatting cases

## Testing
- node tests/weekDateRange.test.js
- node tests/reminderBody.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6a2e2d1d08333a57092ba52db7455