### PR TITLE
Fix Paris context date formatting

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -435,13 +435,18 @@ function parisContext(now = new Date()) {
   const midnightLocal = new Date(parisNow);
   midnightLocal.setHours(0, 0, 0, 0);
   const selectedDate = new Date(midnightLocal.getTime() - offsetMs);
+  const year = parisNow.getFullYear();
+  const month = String(parisNow.getMonth() + 1).padStart(2, "0");
+  const day = String(parisNow.getDate()).padStart(2, "0");
 
   return {
     dayLabel,
     selectedDate,
-    dateIso: selectedDate.toISOString().slice(0, 10),
+    dateIso: `${year}-${month}-${day}`,
   };
 }
+
+exports.parisContext = parisContext;
 
 function monthKeyFromDate(date) {
   const dt = date instanceof Date ? new Date(date.getTime()) : new Date(date);

--- a/tests/parisContext.test.js
+++ b/tests/parisContext.test.js
@@ -1,0 +1,14 @@
+const { parisContext } = require("../functions/index.js");
+
+describe("parisContext", () => {
+  test("uses Paris local date for DST period", () => {
+    const context = parisContext(new Date("2024-09-26T10:00:00.000Z"));
+    expect(context.dateIso).toBe("2024-09-26");
+    expect(context.selectedDate).toBeInstanceOf(Date);
+  });
+
+  test("uses Paris local date for standard time", () => {
+    const context = parisContext(new Date("2024-12-15T10:00:00.000Z"));
+    expect(context.dateIso).toBe("2024-12-15");
+  });
+});


### PR DESCRIPTION
## Summary
- derive `parisContext.dateIso` from the Paris-local date components to avoid UTC rollbacks
- export `parisContext` for reuse and add Jest coverage for DST and standard time scenarios

## Testing
- npx jest tests/parisContext.test.js *(fails: npm registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b0d32e988333a5f006aeb294f0bb