### PR TITLE
Normalize objective reminder day to Europe/Paris

### DIFF
--- a/tests/countObjectivesDueToday.test.js
+++ b/tests/countObjectivesDueToday.test.js
@@ -1,0 +1,31 @@
+const { parisContext, __testables } = require("../functions/index.js");
+
+const { countObjectivesDueToday } = __testables;
+
+describe("countObjectivesDueToday", () => {
+  function makeFetcher(map) {
+    return jest.fn(async (uid, monthKey) => map[monthKey] || []);
+  }
+
+  test("counts objectives stored with Paris-midnight ISO strings and timestamps", async () => {
+    const context = parisContext(new Date("2024-07-15T08:00:00.000Z"));
+    const monthKey = context.dateIso.slice(0, 7);
+
+    const reminderIso = "2024-07-15T00:00:00+02:00";
+    const reminderTimestamp = {
+      toDate: () => new Date("2024-07-15T00:00:00+02:00"),
+    };
+
+    const fetcher = makeFetcher({
+      [monthKey]: [
+        { id: "iso", notifyAt: reminderIso },
+        { id: "timestamp", notifyAt: reminderTimestamp },
+        { id: "other", notifyAt: "2024-07-16T00:00:00+02:00" },
+      ],
+    });
+
+    const count = await countObjectivesDueToday("user", context, { fetchObjectivesByMonth: fetcher });
+    expect(count).toBe(2);
+    expect(fetcher).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize custom reminder dates against Europe/Paris before counting due objectives
- compare due objectives by Paris-based ISO strings and allow dependency injection for testing
- add regression coverage for Paris-midnight reminders stored as ISO strings and Firestore timestamps

## Testing
- npx jest *(fails: npm registry access forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c0f7fe808333b1a7ee472708ba08