### PR TITLE
Fix month boundary objective count

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -602,9 +602,13 @@ async function fetchObjectivesByMonth(uid, monthKey) {
 }
 
 async function countObjectivesDueToday(uid, context, { fetchObjectivesByMonth: fetcher } = {}) {
-  const monthKey = monthKeyFromDate(context.selectedDate);
-  const previousMonth = shiftMonthKey(monthKey, -1);
-  const targetMonths = new Set([monthKey]);
+  const baseMonthKey = toStringOrNull(context?.dateIso)?.slice(0, 7);
+  const monthKey = baseMonthKey || monthKeyFromDate(context.selectedDate);
+  const previousMonth = monthKey ? shiftMonthKey(monthKey, -1) : null;
+  const targetMonths = new Set();
+  if (monthKey) {
+    targetMonths.add(monthKey);
+  }
   if (previousMonth && previousMonth !== monthKey) {
     targetMonths.add(previousMonth);
   }

--- a/tests/countObjectivesDueToday.test.js
+++ b/tests/countObjectivesDueToday.test.js
@@ -28,4 +28,25 @@ describe("countObjectivesDueToday", () => {
     expect(count).toBe(2);
     expect(fetcher).toHaveBeenCalled();
   });
+
+  test("counts objectives for the Paris first day of a month", async () => {
+    const context = parisContext(new Date("2024-07-31T22:15:00.000Z"));
+    const monthKey = context.dateIso.slice(0, 7);
+    const previousMonthKey = "2024-07";
+
+    const fetcher = makeFetcher({
+      [monthKey]: [
+        {
+          id: "first-day",
+          notifyAt: "2024-08-01T00:00:00+02:00",
+        },
+      ],
+      [previousMonthKey]: [],
+    });
+
+    const count = await countObjectivesDueToday("user", context, { fetchObjectivesByMonth: fetcher });
+    expect(count).toBe(1);
+    expect(fetcher).toHaveBeenCalledWith("user", monthKey);
+    expect(fetcher).toHaveBeenCalledWith("user", previousMonthKey);
+  });
 });


### PR DESCRIPTION
## Summary
- derive the objectives month key from the Paris date ISO string when counting daily reminders
- avoid fetching invalid months by only querying when a key is available
- add a regression test covering the first Parisian day of a month

## Testing
- npx jest tests/countObjectivesDueToday.test.js *(fails: npm error 403 when downloading jest)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c64f28b083339f65e46c0d102f2b