### PR TITLE
Document scheduled daily reminders deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Cette V1 est **100% front** (HTML/JS modules), déployable sur GitHub Pages, ave
   - `tokens`: tableau de tokens d’enregistrement.
 
 - `sendDailyRemindersScheduled` — tâche planifiée (Europe/Paris, 6h00) qui exécute `sendDailyRemindersHandler` sans requête HTTP. Cette fonction remplace les déclenchements manuels quotidiens ; conservez l’endpoint `sendDailyReminders` uniquement si un appel manuel reste nécessaire.
+  - Déployez les deux fonctions avec `firebase deploy --only functions:sendDailyReminders,functions:sendDailyRemindersScheduled`.
+  - Si les appels manuels ne sont plus utilisés, supprimez l’ancienne fonction HTTP via `firebase functions:delete sendDailyReminders` ou désactivez son invocation dans la console Firebase.
 
 Les réponses renvoient les compteurs `successCount`, `failureCount`, la liste des `invalidTokens`, ainsi que l’identifiant du message pour les topics/conditions.
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -1081,8 +1081,7 @@ exports.manageTopicSubscriptions = functions
     }
   });
 
-async function sendDailyRemindersHandler() {
-  const context = parisContext();
+async function sendDailyRemindersHandler({ context = parisContext() } = {}) {
   functions.logger.info("sendDailyReminders:start", context);
 
   const tokensByUid = await collectPushTokens();


### PR DESCRIPTION
## Summary
- allow the reusable daily reminder handler to receive an injected context when needed
- document how to deploy the scheduled daily reminder function and disable the legacy HTTP endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79ee3ce2c8333be103af47ab00b32