### PR TITLE
Limit daily grid column width on large screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,8 +413,9 @@
 
     @media (min-width: 1024px) {
       .daily-grid {
-        grid-template-columns:repeat(auto-fit, minmax(360px, 1fr));
+        grid-template-columns:repeat(auto-fit, minmax(360px, min(420px, 100%)));
         justify-content:center;
+        justify-items:center;
         align-items:start;
         gap:2rem;
       }


### PR DESCRIPTION
## Summary
- cap the daily grid column width on desktop viewports to keep cards from stretching too wide
- center grid content within each cell so single cards stay centered in wide layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7af78dd348333944b46f45839ba5c