### PR TITLE
Document grid column width cap for daily layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,6 +413,7 @@
 
     @media (min-width: 1024px) {
       .daily-grid {
+        /* Limiter la largeur des colonnes pour conserver des cartes centrées */
         grid-template-columns:repeat(auto-fit, minmax(360px, min(420px, 100%)));
         justify-content:center;
         justify-items:center;


### PR DESCRIPTION
## Summary
- add a comment in the large-screen daily grid styles to explain the column width cap that keeps cards centered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7b491e6a4833381890dad5889a97b