### PR TITLE
Update reminder notification body for objective-only days

### DIFF
--- a/functions/reminder.js
+++ b/functions/reminder.js
@@ -8,8 +8,11 @@ function buildReminderBody(firstName, consigneCount, objectiveCount) {
   if (consigneCount === 0 && objectiveCount === 0) {
     return `${prefix}tu n’as rien à remplir aujourd’hui.`;
   }
-  const consigneLabel = pluralize(consigneCount, "consigne");
   const objectiveLabel = pluralize(objectiveCount, "objectif");
+  if (consigneCount === 0) {
+    return `${prefix}tu as ${objectiveCount} ${objectiveLabel} à remplir aujourd’hui.`;
+  }
+  const consigneLabel = pluralize(consigneCount, "consigne");
   return `${prefix}tu as ${consigneCount} ${consigneLabel} et ${objectiveCount} ${objectiveLabel} à remplir aujourd’hui.`;
 }
 

--- a/tests/reminderBody.test.js
+++ b/tests/reminderBody.test.js
@@ -21,8 +21,8 @@ function runTests() {
 
   assertEqual(
     buildReminderBody("", 0, 1),
-    "tu as 0 consignes et 1 objectif à remplir aujourd’hui.",
-    "Le message doit afficher zéro consigne explicitement",
+    "tu as 1 objectif à remplir aujourd’hui.",
+    "Le message doit se concentrer sur les objectifs lorsqu’il n’y a pas de consignes",
   );
 
   assertEqual(


### PR DESCRIPTION
## Summary
- adjust `buildReminderBody` to focus on objectives when there are no consignes
- update the reminder body tests to match the new objective-only message

## Testing
- node tests/reminderBody.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7ccc8197483338d1b2260727bdd09