### PR TITLE
Align daily consigne styling with practice cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,12 +316,9 @@
       gap:1.1rem;
     }
     .daily-consigne {
-      background:#fff;
-      border-radius:1rem;
-      border:1px solid rgba(148,163,184,.22);
-      box-shadow:0 6px 16px rgba(15,23,42,.04);
-      padding:1rem 1.2rem;
-      display:grid;
+      width:100%;
+      display:flex;
+      flex-direction:column;
       gap:.75rem;
       transition:background .2s ease,border-color .2s ease,box-shadow .2s ease;
     }

--- a/modes.js
+++ b/modes.js
@@ -2461,28 +2461,28 @@ async function renderDaily(ctx, root, opts = {}) {
     const previous = previousAnswers?.get(item.id);
     const itemCard = document.createElement("div");
     const tone = priorityTone(item.priority);
-    itemCard.className = `daily-consigne priority-surface priority-surface-${tone}`;
+    itemCard.className = `daily-consigne consigne-card card p-3 space-y-3 priority-surface priority-surface-${tone}`;
     if (isChild) {
-      itemCard.classList.add("daily-consigne--child");
+      itemCard.classList.add("daily-consigne--child", "consigne-card--child");
       if (item.parentId) {
         itemCard.dataset.parentId = item.parentId;
       } else {
         delete itemCard.dataset.parentId;
       }
     } else {
-      itemCard.classList.add("daily-consigne--parent");
+      itemCard.classList.add("daily-consigne--parent", "consigne-card--parent");
       delete itemCard.dataset.parentId;
     }
     itemCard.innerHTML = `
-      <div class="daily-consigne__top">
-        <div class="daily-consigne__title">
-          <div class="font-semibold">${escapeHtml(item.text)}</div>
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="flex flex-wrap items-center gap-2">
+          <h4 class="font-semibold">${escapeHtml(item.text)}</h4>
           ${prioChip(Number(item.priority) || 2)}
           ${srBadge(item)}
         </div>
         ${consigneActions()}
       </div>
-      <div class="daily-consigne__field">${inputForType(item, previous?.value ?? null)}</div>
+      ${inputForType(item, previous?.value ?? null)}
     `;
 
     const bH = itemCard.querySelector(".js-histo");


### PR DESCRIPTION
## Summary
- update the daily consigne renderer to reuse the card structure from practice mode so both views share the same layout
- tweak the daily consigne styles to lean on the shared card styling and fill the available width

## Testing
- no automated tests were run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d81a58751c8333a126ccb23f23a354