### PR TITLE
Align daily consigne cards with practice styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,34 +315,6 @@
       display:grid;
       gap:1.1rem;
     }
-    .daily-consigne {
-      background:#fff;
-      border-radius:1rem;
-      border:1px solid rgba(148,163,184,.22);
-      box-shadow:0 6px 16px rgba(15,23,42,.04);
-      padding:1rem 1.2rem;
-      display:grid;
-      gap:.75rem;
-      transition:background .2s ease,border-color .2s ease,box-shadow .2s ease;
-    }
-    .daily-consigne:last-child { border-bottom:none; }
-    .daily-consigne__top {
-      display:flex;
-      flex-wrap:wrap;
-      align-items:center;
-      justify-content:space-between;
-      gap:1rem;
-    }
-    .daily-consigne__title {
-      display:flex;
-      flex:1 1 auto;
-      flex-wrap:wrap;
-      align-items:center;
-      gap:.5rem;
-    }
-    .daily-consigne__field {
-      display:block;
-    }
     .daily-consigne__actions {
       display:flex;
       flex:0 0 auto;
@@ -401,9 +373,6 @@
       display:grid;
       gap:.75rem;
       margin-top:.5rem;
-    }
-    .daily-consigne--child {
-      margin-left:1.2rem;
     }
     .consigne-card--child {
       margin-left:1rem;

--- a/modes.js
+++ b/modes.js
@@ -2461,28 +2461,28 @@ async function renderDaily(ctx, root, opts = {}) {
     const previous = previousAnswers?.get(item.id);
     const itemCard = document.createElement("div");
     const tone = priorityTone(item.priority);
-    itemCard.className = `daily-consigne priority-surface priority-surface-${tone}`;
+    itemCard.className = `consigne-card card p-3 space-y-3 priority-surface priority-surface-${tone}`;
     if (isChild) {
-      itemCard.classList.add("daily-consigne--child");
+      itemCard.classList.add("consigne-card--child");
       if (item.parentId) {
         itemCard.dataset.parentId = item.parentId;
       } else {
         delete itemCard.dataset.parentId;
       }
     } else {
-      itemCard.classList.add("daily-consigne--parent");
+      itemCard.classList.add("consigne-card--parent");
       delete itemCard.dataset.parentId;
     }
     itemCard.innerHTML = `
-      <div class="daily-consigne__top">
-        <div class="daily-consigne__title">
-          <div class="font-semibold">${escapeHtml(item.text)}</div>
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="flex flex-wrap items-center gap-2">
+          <h4 class="font-semibold">${escapeHtml(item.text)}</h4>
           ${prioChip(Number(item.priority) || 2)}
           ${srBadge(item)}
         </div>
         ${consigneActions()}
       </div>
-      <div class="daily-consigne__field">${inputForType(item, previous?.value ?? null)}</div>
+      ${inputForType(item, previous?.value ?? null)}
     `;
 
     const bH = itemCard.querySelector(".js-histo");


### PR DESCRIPTION
## Summary
- reuse the consigne card markup in daily mode so the cards match the practice layout
- remove obsolete daily-specific styling from the daily view while keeping shared action styles

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d81a58751c8333a126ccb23f23a354