### PR TITLE
Align daily consignes layout with practice tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,10 +382,9 @@
 
     @media (min-width: 1024px) {
       .daily-grid {
-        /* Limiter la largeur des colonnes pour conserver des cartes centrées */
-        grid-template-columns:repeat(auto-fit, minmax(360px, min(420px, 100%)));
-        justify-content:center;
-        justify-items:center;
+        grid-template-columns:minmax(0, 1fr);
+        justify-content:stretch;
+        justify-items:stretch;
         align-items:start;
         gap:2rem;
       }
@@ -397,6 +396,7 @@
       }
       .daily-category {
         height:100%;
+        width:100%;
       }
     }
 


### PR DESCRIPTION
## Summary
- update the daily grid layout styles so daily consigne cards stretch across the available width on large screens
- ensure daily category cards expand to fill the grid column similar to the practice tab presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92eb53ae48333bf3e4c9555d3c3b5