### PR TITLE
Fix daily header overflow on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,8 @@
       header h1{ font-size:1rem; }
       .install-banner{ flex-direction:column; align-items:flex-start; text-align:left; }
       .install-banner__action{ padding-top:.25rem; }
+      .day-nav{ min-width:0; width:100%; }
+      .daily-header-actions{ margin-left:0; width:100%; justify-content:flex-start; flex-wrap:wrap; }
     }
 
     /* utilitaire pour masquer la scrollbar (déjà utilisé ci-dessus) */

--- a/modes.js
+++ b/modes.js
@@ -2436,7 +2436,7 @@ async function renderDaily(ctx, root, opts = {}) {
           <span aria-hidden="true">→</span>
         </button>
       </div>
-      <div class="ml-auto flex items-center gap-2">${smallBtn("📊 Tableau de bord", "js-dashboard")}${smallBtn("+ Nouvelle consigne", "js-new")}</div>
+      <div class="daily-header-actions flex items-center gap-2">${smallBtn("📊 Tableau de bord", "js-dashboard")}${smallBtn("+ Nouvelle consigne", "js-new")}</div>
     </div>
   `;
   container.appendChild(card);


### PR DESCRIPTION
## Summary
- add a dedicated class to the daily header actions container so its layout can be adjusted
- relax the day navigation sizing on narrow screens to keep the daily card centered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d958156900833397633d89d9da5e45