### PR TITLE
Fix daily category header wrapping on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,12 +375,13 @@
     }
     .daily-category__header {
       display:flex;
-      align-items:center;
+      align-items:flex-start;
       justify-content:space-between;
       gap:1rem;
       padding-bottom:.9rem;
       margin-bottom:1.1rem;
       border-bottom:1px solid rgba(148,163,184,.25);
+      flex-wrap:wrap;
     }
     .daily-category__name {
       font-weight:700;
@@ -390,6 +391,9 @@
       display:flex;
       align-items:center;
       gap:.5rem;
+      flex:1 1 100%;
+      min-width:0;
+      word-break:break-word;
     }
     .daily-category__name::before {
       content:"";
@@ -405,6 +409,15 @@
       padding:.2rem .4rem;
       text-transform:uppercase;
       letter-spacing:.08em;
+      margin-left:auto;
+      flex:0 0 auto;
+      text-align:right;
+    }
+    @media (max-width: 480px) {
+      .daily-category__count {
+        width:100%;
+        margin-left:0;
+      }
     }
     .daily-category__items {
       display:grid;


### PR DESCRIPTION
## Summary
- allow the daily category header to wrap so long titles do not overflow
- let the category name shrink and wrap onto multiple lines while keeping the counter aligned
- add a mobile breakpoint so the counter spans the full width on narrow screens

## Testing
- manual verification in mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68d95de289a483338dc09b67dea23bb2