### PR TITLE
Adjust daily header layout for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,9 +414,16 @@
       text-align:right;
     }
     @media (max-width: 480px) {
+      .daily-category__header {
+        flex-direction:column;
+        align-items:flex-start;
+        gap:.75rem;
+      }
       .daily-category__count {
-        width:100%;
         margin-left:0;
+        text-align:left;
+        align-self:flex-start;
+        width:100%;
       }
     }
     .daily-category__items {


### PR DESCRIPTION
## Summary
- stack the daily category header elements vertically on very small screens
- left-align and constrain the daily entry counter to avoid stretching the header

## Testing
- playwright screenshot of daily view at 375px width

------
https://chatgpt.com/codex/tasks/task_e_68d96114933083338bbb13d59e66cdf1