### PR TITLE
Adjust daily journal header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,13 +378,13 @@
     }
     .daily-category__header {
       display:flex;
-      align-items:flex-start;
+      align-items:center;
       justify-content:space-between;
       gap:1rem;
       padding-bottom:.9rem;
       margin-bottom:1.1rem;
       border-bottom:1px solid rgba(148,163,184,.25);
-      flex-wrap:wrap;
+      flex-wrap:nowrap;
     }
     .daily-category__name {
       font-weight:700;
@@ -394,7 +394,7 @@
       display:flex;
       align-items:center;
       gap:.5rem;
-      flex:1 1 100%;
+      flex:1 1 auto;
       min-width:0;
       word-break:break-word;
     }
@@ -415,11 +415,12 @@
       margin-left:auto;
       flex:0 0 auto;
       text-align:right;
+      align-self:center;
     }
     @media (max-width: 480px) {
       .daily-category__header {
-        flex-direction:column;
         align-items:flex-start;
+        flex-wrap:wrap;
         gap:.75rem;
       }
       .daily-category__count {


### PR DESCRIPTION
## Summary
- align daily category headers vertically and prevent unwanted wrapping on wide screens
- adjust category name flex behavior to allow space for the count badge
- ensure the count badge aligns to the right while wrapping cleanly on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d966e384408333af7917bb07a5d098