### PR TITLE
Ajuste des alignements mobiles pour la vue journalier

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,7 @@
     }
     @media (max-width: 480px) {
       .daily-category {
-        padding:1.25rem 1.35rem;
+        padding:1.1rem .85rem 1.3rem;
       }
       .daily-category__header {
         align-items:flex-start;
@@ -437,6 +437,9 @@
         text-align:left;
         align-self:flex-start;
         width:100%;
+      }
+      .consigne-group__children {
+        padding-inline:0;
       }
       .consigne-card--child {
         margin-left:0;

--- a/modes.js
+++ b/modes.js
@@ -2068,7 +2068,7 @@ async function renderPractice(ctx, root, _opts = {}) {
   ].map((part) => String(part)).join(":");
 
   const card = document.createElement("section");
-  card.className = "card p-4 space-y-4";
+  card.className = "card space-y-4 p-3 sm:p-4";
   card.innerHTML = `
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-2">
@@ -2421,7 +2421,7 @@ async function renderDaily(ctx, root, opts = {}) {
   const isTodaySelected = Schema.todayKey() === selectedKey;
 
   const card = document.createElement("section");
-  card.className = "card p-4 space-y-4";
+  card.className = "card space-y-4 p-3 sm:p-4";
   card.innerHTML = `
     <div class="flex flex-wrap items-center gap-2">
       <div class="day-nav" data-day-nav>


### PR DESCRIPTION
## Summary
- réduit le padding mobile des cartes de catégories journalières pour aligner le contenu sur la navigation
- supprime le padding horizontal des sous-consignes en mobile pour conserver l’alignement
- harmonise le padding des cartes générées en JS avec une variante compacte côté mobile

## Testing
- Manual: Vérification responsive de la vue « Journalier » (Chrome mobile 375 px)


------
https://chatgpt.com/codex/tasks/task_e_68d973c138ac8333b3504c008b208257