### PR TITLE
Tighten daily view layout on sub-360px screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,43 @@
         border-left:2px solid rgba(148,163,184,.28);
       }
     }
+    @media (max-width: 360px) {
+      html,
+      body {
+        font-size:clamp(14px, 4vw, 15px);
+        line-height:1.45;
+      }
+      .daily-category {
+        padding:.9rem .6rem 1rem;
+      }
+      .consigne-group__children {
+        padding:.25rem .55rem .7rem;
+      }
+      .consigne-card {
+        padding:.75rem .8rem;
+      }
+      .tab {
+        padding:.4rem .65rem;
+        font-size:.78rem;
+        gap:.4rem;
+      }
+      .day-nav {
+        padding:.25rem .4rem;
+        gap:.35rem;
+        min-width:11.5rem;
+        width:clamp(11.5rem, 72vw, 15rem);
+      }
+      .day-nav-label {
+        font-size:.85rem;
+      }
+      .day-nav-today {
+        font-size:.65rem;
+      }
+      .daily-category__name {
+        font-size:1rem;
+        gap:.4rem;
+      }
+    }
     .daily-category__items {
       display:grid;
       gap:1.25rem;


### PR DESCRIPTION
## Summary
- add a max-width: 360px media query that scales the base typography and line height
- tighten the daily navigation, category, and consigne paddings for ultra-small viewports

## Testing
- manual inspection at 320px using the browser dev tools

------
https://chatgpt.com/codex/tasks/task_e_68d978b723488333b6674b484316d830