### PR TITLE
Adjust high priority card styling to remove blue background

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,9 +749,9 @@
       position:relative;
     }
     .priority-surface-high {
-      background:#eff6ff;
-      border-color:#bfdbfe;
-      box-shadow:0 6px 18px rgba(59,130,246,0.18);
+      background:#f9fafb;
+      border:2px solid #1f2937;
+      box-shadow:0 8px 24px rgba(15,23,42,0.18);
     }
     .priority-surface-medium {
       background:#ffffff;
@@ -764,9 +764,9 @@
     }
 
     .consigne-card.priority-surface-high {
-      background:#eff6ff;
-      border-color:#bfdbfe;
-      box-shadow:0 6px 18px rgba(59,130,246,0.18);
+      background:#f9fafb;
+      border:2px solid #1f2937;
+      box-shadow:0 8px 24px rgba(15,23,42,0.18);
     }
     .consigne-card.priority-surface-low {
       background:#f8fafc;


### PR DESCRIPTION
## Summary
- replace the blue background on high priority surfaces with a neutral tone and reinforced border
- update high priority consigne cards to use the same neutral styling and enhanced shadow for hierarchy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5ead40d48333ad053f585c6a0ba9