### PR TITLE
Fix consigne card overflow for action menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,6 +582,9 @@
       overflow:hidden;
       transition:height .2s ease, opacity .2s ease;
     }
+    .consigne-card--open .consigne-card__content {
+      overflow:visible;
+    }
     .consigne-card__toolbar {
       display:flex;
       justify-content:flex-end;

--- a/modes.js
+++ b/modes.js
@@ -1462,9 +1462,11 @@ function animateCollapsible(content, expanded) {
   const clean = () => {
     content.style.height = "";
     content.style.opacity = "";
+    content.style.overflow = "";
   };
   if (expanded) {
     content.hidden = false;
+    content.style.overflow = "hidden";
     content.style.height = "0px";
     content.style.opacity = "0";
     const openHandler = (event) => {
@@ -1483,6 +1485,7 @@ function animateCollapsible(content, expanded) {
     });
   } else {
     const fullHeight = content.scrollHeight;
+    content.style.overflow = "hidden";
     content.style.height = `${fullHeight}px`;
     content.style.opacity = "1";
     const closeHandler = (event) => {


### PR DESCRIPTION
## Summary
- allow open consigne cards to expose their content overflow so the context menu is no longer clipped
- keep the collapsible animation smooth by forcing overflow hidden only during transition timing

## Testing
- Manual visual check of the consigne menu in desktop and mobile viewports

------
https://chatgpt.com/codex/tasks/task_e_68dd6868e2748333b445333f4ecaf81b