### PR TITLE
Convert consigne cards to popover content

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,7 @@
     .consigne-card {
       position:relative;
       transition:background-color .2s ease, border-color .2s ease, background-image .2s ease;
+      overflow:visible;
     }
     .consigne-card--likert-positive {
       background-image:linear-gradient(rgba(22,163,74,.14), rgba(22,163,74,.14));
@@ -558,7 +559,7 @@
       color:var(--muted);
       transition:transform .2s ease;
     }
-    .consigne-card--open .consigne-card__toggle::after {
+    .consigne-card--active .consigne-card__toggle::after {
       transform:rotate(90deg);
       color:var(--accent-400);
     }
@@ -580,11 +581,29 @@
       margin-left:auto;
     }
     .consigne-card__content {
-      overflow:hidden;
-      transition:height .2s ease, opacity .2s ease;
+      position:absolute;
+      left:0;
+      right:0;
+      top:calc(100% + .5rem);
+      display:none;
+      visibility:hidden;
+      opacity:0;
+      pointer-events:none;
+      transition:opacity .2s ease, transform .2s ease;
+      transform:translateY(-.25rem);
+      z-index:20;
+      background:var(--card-bg);
+      border:1px solid rgba(148,163,184,.35);
+      border-radius:1rem;
+      box-shadow:0 18px 40px rgba(15,23,42,.18);
+      padding:.75rem;
     }
-    .consigne-card--open .consigne-card__content {
-      overflow:visible;
+    .consigne-card--active .consigne-card__content {
+      display:block;
+      visibility:visible;
+      opacity:1;
+      pointer-events:auto;
+      transform:translateY(0);
     }
     .consigne-card__toolbar {
       display:flex;


### PR DESCRIPTION
## Summary
- toggle collapsible cards by switching the hidden attribute and a new active state instead of animating heights
- restyle consigne card content as an absolutely positioned popover that no longer expands the parent card
- remove the unused animation helper utilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6d674120833387a8789c13e06849