### PR TITLE
Déplacer le menu des consignes dans l'entête des cartes

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,9 +576,13 @@
     .consigne-card__aside {
       display:flex;
       align-items:center;
-      gap:.4rem;
+      gap:.5rem;
       flex:0 0 auto;
       margin-left:auto;
+      justify-content:flex-end;
+    }
+    .consigne-card__aside > * {
+      flex-shrink:0;
     }
     .consigne-card__content {
       position:absolute;
@@ -604,10 +608,6 @@
       opacity:1;
       pointer-events:auto;
       transform:translateY(0);
-    }
-    .consigne-card__toolbar {
-      display:flex;
-      justify-content:flex-end;
     }
     .consigne-card__body {
       margin-top:.75rem;

--- a/modes.js
+++ b/modes.js
@@ -2462,12 +2462,10 @@ async function renderPractice(ctx, root, _opts = {}) {
           </button>
           <div class="consigne-card__aside">
             ${srBadge(c)}
+            ${consigneActions()}
           </div>
         </div>
         <div class="consigne-card__content" data-consigne-content hidden>
-          <div class="consigne-card__toolbar">
-            ${consigneActions()}
-          </div>
           <div class="consigne-card__body">
             ${inputForType(c)}
           </div>
@@ -2906,12 +2904,10 @@ async function renderDaily(ctx, root, opts = {}) {
         </button>
         <div class="consigne-card__aside">
           ${srBadge(item)}
+          ${consigneActions()}
         </div>
       </div>
       <div class="consigne-card__content" data-consigne-content hidden>
-        <div class="consigne-card__toolbar">
-          ${consigneActions()}
-        </div>
         <div class="consigne-card__body">
           ${inputForType(item, previous?.value ?? null)}
         </div>


### PR DESCRIPTION
## Summary
- place the contextual action menu inside the consigne card header next to the SR toggle
- drop the now-empty toolbar wrapper from practice and daily card markup
- adjust the card header styling so the SR badge and menu button stay aligned on all viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd711e3b18833387c9aa5c99c0bdcb