### PR TITLE
Add star indicator for high priority cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -772,10 +772,18 @@
     .priority-surface {
       position:relative;
     }
+    .priority-chip {
+      display:inline-flex;
+      align-items:center;
+      margin-left:.35rem;
+      font-size:.95rem;
+      line-height:1;
+      color:#facc15;
+    }
     .priority-surface-high {
-      background:#f9fafb;
-      border:2px solid #1f2937;
-      box-shadow:0 8px 24px rgba(15,23,42,0.18);
+      background:#fffbeb;
+      border:1px solid rgba(250,204,21,.35);
+      box-shadow:none;
     }
     .priority-surface-medium {
       background:#ffffff;
@@ -788,9 +796,9 @@
     }
 
     .consigne-card.priority-surface-high {
-      background:#f9fafb;
-      border:2px solid #1f2937;
-      box-shadow:0 8px 24px rgba(15,23,42,0.18);
+      background:#fffbeb;
+      border:1px solid rgba(250,204,21,.35);
+      box-shadow:none;
     }
     .consigne-card.priority-surface-low {
       background:#f8fafc;

--- a/modes.js
+++ b/modes.js
@@ -95,7 +95,9 @@ function priorityLabelFromTone(tone) {
 function prioChip(p) {
   const tone = priorityTone(p);
   const lbl = priorityLabelFromTone(tone);
-  return `<span class="sr-only" data-priority="${tone}">Priorité ${lbl}</span>`;
+  const accessible = `<span class="sr-only" data-priority="${tone}">Priorité ${lbl}</span>`;
+  if (tone !== "high") return accessible;
+  return `<span class="priority-chip" data-priority="${tone}" aria-hidden="true">⭐</span>${accessible}`;
 }
 
 const LIKERT_STATUS_CLASSES = [


### PR DESCRIPTION
## Summary
- add a visual star marker for high priority cards while keeping accessible text
- lighten the high priority surface styling and add subtle star icon styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd75537fb08333a4cb10ed0aa31200