### PR TITLE
Improve Likert status handling and highlight contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,16 +520,16 @@
       overflow:visible;
     }
     .consigne-card--likert-positive {
-      background-image:linear-gradient(rgba(22,163,74,.14), rgba(22,163,74,.14));
-      border-color:rgba(22,163,74,.35);
+      background-image:linear-gradient(rgba(34,197,94,.22), rgba(34,197,94,.22));
+      border-color:rgba(22,163,74,.6);
     }
     .consigne-card--likert-neutral {
-      background-image:linear-gradient(rgba(234,179,8,.16), rgba(234,179,8,.16));
-      border-color:rgba(202,138,4,.35);
+      background-image:linear-gradient(rgba(234,179,8,.26), rgba(234,179,8,.26));
+      border-color:rgba(202,138,4,.6);
     }
     .consigne-card--likert-negative {
-      background-image:linear-gradient(rgba(239,68,68,.16), rgba(239,68,68,.16));
-      border-color:rgba(220,38,38,.4);
+      background-image:linear-gradient(rgba(248,113,113,.24), rgba(248,113,113,.24));
+      border-color:rgba(220,38,38,.65);
     }
     .consigne-card__header {
       display:flex;


### PR DESCRIPTION
## Summary
- centralize Likert select detection and normalize type handling before syncing status classes
- keep card constructors wired to the Likert enhancer for parents and children
- strengthen the positive/neutral/negative card backgrounds and borders for clearer feedback

## Testing
- browser_container.run_playwright_script (Likert select drives status classes)


------
https://chatgpt.com/codex/tasks/task_e_68dd7c9ce76083339b0f1fbf29db0d6b