### PR TITLE
Stack consigne children below response fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,9 +597,9 @@
     }
     .consigne-card__body {
       display:flex;
-      align-items:flex-start;
+      flex-direction:column;
+      align-items:stretch;
       gap:.75rem;
-      flex-wrap:wrap;
       width:100%;
     }
     .consigne-card__body > * {
@@ -712,6 +712,7 @@
       border-top:1px dashed rgba(148,163,184,.35);
       display:grid;
       gap:.75rem;
+      width:100%;
     }
     .consigne-card__children-label {
       font-size:.8rem;

--- a/modes.js
+++ b/modes.js
@@ -2674,9 +2674,10 @@ async function renderPractice(ctx, root, _opts = {}) {
           badge.textContent = `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`;
           aside.prepend(badge);
         }
-        const body = parentCard.querySelector(".consigne-card__body")
-          || parentCard.querySelector(".consigne-card__content");
-        if (body) {
+        const content = parentCard.querySelector(".consigne-card__content");
+        const body = parentCard.querySelector(".consigne-card__body");
+        const targetContainer = content || body || parentCard;
+        if (targetContainer) {
           const childrenContainer = document.createElement("div");
           childrenContainer.className = "consigne-card__children";
           const label = document.createElement("div");
@@ -2692,7 +2693,11 @@ async function renderPractice(ctx, root, _opts = {}) {
           });
           childrenContainer.appendChild(label);
           childrenContainer.appendChild(list);
-          body.appendChild(childrenContainer);
+          if (content && body) {
+            content.appendChild(childrenContainer);
+          } else {
+            targetContainer.appendChild(childrenContainer);
+          }
         }
       }
       wrapper.appendChild(parentCard);


### PR DESCRIPTION
## Summary
- append rendered child consignes after the parent response area so they occupy the full card width
- adjust the consigne card body and child container styles to stack vertically on all breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd80b3e08483338096ecf399745d3c