### PR TITLE
Ensure Likert card colors override priority surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,18 +519,6 @@
       transition:background-color .2s ease, border-color .2s ease, background-image .2s ease;
       overflow:visible;
     }
-    .consigne-card--likert-positive {
-      background-image:linear-gradient(rgba(34,197,94,.22), rgba(34,197,94,.22));
-      border-color:rgba(22,163,74,.6);
-    }
-    .consigne-card--likert-neutral {
-      background-image:linear-gradient(rgba(234,179,8,.26), rgba(234,179,8,.26));
-      border-color:rgba(202,138,4,.6);
-    }
-    .consigne-card--likert-negative {
-      background-image:linear-gradient(rgba(248,113,113,.24), rgba(248,113,113,.24));
-      border-color:rgba(220,38,38,.65);
-    }
     .consigne-card__header {
       display:flex;
       align-items:center;
@@ -914,6 +902,21 @@
     .consigne-card.priority-surface-low {
       background:#f8fafc;
       border-color:#e2e8f0;
+    }
+
+    .consigne-card.consigne-card--likert-positive {
+      background-color:rgba(34,197,94,.22);
+      border-color:rgba(22,163,74,.6);
+    }
+
+    .consigne-card.consigne-card--likert-neutral {
+      background-color:rgba(234,179,8,.26);
+      border-color:rgba(202,138,4,.6);
+    }
+
+    .consigne-card.consigne-card--likert-negative {
+      background-color:rgba(248,113,113,.24);
+      border-color:rgba(220,38,38,.65);
     }
 
     .btn-saved{ background:#22C55E; } /* vert doux rapide pour le flash */


### PR DESCRIPTION
## Summary
- move the Likert state styles so they apply after the priority-surface overrides
- switch the Likert backgrounds to flat colors and retain their border accents

## Testing
- not run (manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68dd87de53408333bac7e1e4c9940a98