### PR TITLE
Affiner les nuances des statuts Likert

### DIFF
--- a/index.html
+++ b/index.html
@@ -904,9 +904,15 @@
       border-color:#e2e8f0;
     }
 
-    .consigne-card.consigne-card--likert-positive {
+    .consigne-card.consigne-card--likert-positive,
+    .consigne-card.consigne-card--likert-positive-strong {
       background-color:rgba(34,197,94,.22);
-      border-color:rgba(22,163,74,.6);
+      border-color:rgba(21,128,61,.7);
+    }
+
+    .consigne-card.consigne-card--likert-positive-soft {
+      background-color:rgba(187,247,208,.32);
+      border-color:rgba(74,222,128,.6);
     }
 
     .consigne-card.consigne-card--likert-neutral {
@@ -914,7 +920,13 @@
       border-color:rgba(202,138,4,.6);
     }
 
-    .consigne-card.consigne-card--likert-negative {
+    .consigne-card.consigne-card--likert-negative-soft {
+      background-color:rgba(254,202,202,.32);
+      border-color:rgba(248,113,113,.55);
+    }
+
+    .consigne-card.consigne-card--likert-negative,
+    .consigne-card.consigne-card--likert-negative-strong {
       background-color:rgba(248,113,113,.24);
       border-color:rgba(220,38,38,.65);
     }

--- a/modes.js
+++ b/modes.js
@@ -102,8 +102,12 @@ function prioChip(p) {
 
 const LIKERT_STATUS_CLASSES = [
   "consigne-card--likert-positive",
-  "consigne-card--likert-neutral",
   "consigne-card--likert-negative",
+  "consigne-card--likert-positive-strong",
+  "consigne-card--likert-positive-soft",
+  "consigne-card--likert-neutral",
+  "consigne-card--likert-negative-soft",
+  "consigne-card--likert-negative-strong",
 ];
 const LIKERT_STATUS_TYPES = ["likert5", "likert6", "yesno"];
 const LIKERT_STATUS_FIELD_SELECTOR = LIKERT_STATUS_TYPES.map(
@@ -133,19 +137,24 @@ function likertStatusKind(type, rawValue) {
   if (normalizedType === "likert5") {
     const num = Number(value);
     if (!Number.isFinite(num)) return null;
-    if (num >= 3) return "positive";
-    if (num <= 1) return "negative";
-    return "neutral";
+    if (num >= 4) return "positive-strong";
+    if (num === 3) return "positive-soft";
+    if (num === 2) return "neutral";
+    if (num === 1) return "negative-soft";
+    if (num <= 0) return "negative-strong";
+    return null;
   }
   if (normalizedType === "likert6") {
-    if (value === "yes" || value === "rather_yes") return "positive";
+    if (value === "yes") return "positive-strong";
+    if (value === "rather_yes") return "positive-soft";
     if (value === "medium" || value === "no_answer") return "neutral";
-    if (value === "rather_no" || value === "no") return "negative";
+    if (value === "rather_no") return "negative-soft";
+    if (value === "no") return "negative-strong";
     return null;
   }
   if (normalizedType === "yesno") {
-    if (value === "yes") return "positive";
-    if (value === "no") return "negative";
+    if (value === "yes") return "positive-strong";
+    if (value === "no") return "negative-strong";
     return null;
   }
   return null;


### PR DESCRIPTION
## Summary
- étend la détection des réponses Likert pour générer des classes positives/négatives différenciées
- ajoute les styles correspondants avec des palettes nuancées pour ces nouvelles classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8b77e9288333bcb49e00bcd1f7d5