### PR TITLE
Refine consigne list card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,7 +461,10 @@
         padding-left:.5rem;
       }
       .consigne-card {
-        padding:.75rem .8rem;
+        padding:.7rem .75rem;
+      }
+      .consigne-card--compact {
+        padding:.55rem .65rem;
       }
       .tab {
         padding:.4rem .65rem;
@@ -516,14 +519,25 @@
     }
     .consigne-card {
       position:relative;
-      transition:background-color .2s ease, border-color .2s ease, background-image .2s ease;
+      background:var(--card-bg);
+      border:1px solid rgba(148,163,184,.26);
+      border-radius:.85rem;
+      padding:.75rem 1rem;
+      box-shadow:0 1px 2px rgba(15,23,42,.08);
+      transition:background-color .2s ease, border-color .2s ease, background-image .2s ease, box-shadow .2s ease;
       overflow:visible;
+    }
+    .consigne-card--compact {
+      padding:.6rem .85rem;
+      border-radius:.7rem;
+      box-shadow:0 1px 0 rgba(15,23,42,.08);
     }
     .consigne-card__header {
       display:flex;
       align-items:center;
-      gap:.75rem;
+      gap:.5rem;
       flex-wrap:nowrap;
+      min-height:2.5rem;
     }
     .consigne-card__toggle {
       display:flex;
@@ -802,7 +816,12 @@
 
     .consigne-group {
       display:grid;
-      gap:.5rem;
+      gap:.4rem;
+      padding:.35rem 0;
+      border-bottom:1px solid rgba(148,163,184,.2);
+    }
+    .consigne-group:last-child {
+      border-bottom:none;
     }
     .consigne-card__children {
       margin-top:1rem;

--- a/modes.js
+++ b/modes.js
@@ -2846,7 +2846,7 @@ async function renderPractice(ctx, root, _opts = {}) {
     const makeItem = (c, { isChild = false } = {}) => {
       const tone = priorityTone(c.priority);
       const el = document.createElement("div");
-      el.className = `consigne-card card p-3 priority-surface priority-surface-${tone}`;
+      el.className = `consigne-card priority-surface priority-surface-${tone}`;
       el.dataset.id = c.id;
       if (isChild) {
         el.classList.add("consigne-card--child");
@@ -2857,7 +2857,7 @@ async function renderPractice(ctx, root, _opts = {}) {
         }
         el.draggable = false;
       } else {
-        el.classList.add("consigne-card--parent");
+        el.classList.add("consigne-card--parent", "consigne-card--compact");
         delete el.dataset.parentId;
         el.draggable = true;
       }
@@ -3286,7 +3286,7 @@ async function renderDaily(ctx, root, opts = {}) {
     const previous = previousAnswers?.get(item.id);
     const itemCard = document.createElement("div");
     const tone = priorityTone(item.priority);
-    itemCard.className = `consigne-card card p-3 priority-surface priority-surface-${tone}`;
+    itemCard.className = `consigne-card priority-surface priority-surface-${tone}`;
     if (isChild) {
       itemCard.classList.add("consigne-card--child");
       if (item.parentId) {
@@ -3295,7 +3295,7 @@ async function renderDaily(ctx, root, opts = {}) {
         delete itemCard.dataset.parentId;
       }
     } else {
-      itemCard.classList.add("consigne-card--parent");
+      itemCard.classList.add("consigne-card--parent", "consigne-card--compact");
       delete itemCard.dataset.parentId;
     }
     itemCard.innerHTML = `


### PR DESCRIPTION
## Summary
- replace the generic card utility classes with the dedicated `consigne-card--compact` modifier in list renderers
- tighten list spacing, add subtle separators, and align headers so the title, value, and menu share a single row
- ensure compact styling avoids affecting child consigne cards while keeping density comfortable on desktop and mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd91379e2083338bfbfd1013387b0b