### PR TITLE
Improve consigne card header responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,17 +533,21 @@
       box-shadow:0 1px 0 rgba(15,23,42,.08);
     }
     .consigne-card__header {
-      display:flex;
+      display:grid;
+      grid-template-columns:minmax(0,1fr) auto auto;
+      grid-template-areas:"title meta aside";
       align-items:center;
-      gap:.5rem;
-      flex-wrap:nowrap;
+      column-gap:.75rem;
+      row-gap:.35rem;
       min-height:2.5rem;
     }
     .consigne-card__toggle {
+      grid-area:title;
       display:flex;
       align-items:center;
       gap:.5rem;
-      flex:1 1 auto;
+      justify-content:flex-start;
+      width:100%;
       min-width:0;
       background:none;
       border:none;
@@ -575,8 +579,16 @@
       min-width:0;
       word-break:break-word;
     }
+    .consigne-card__meta {
+      grid-area:meta;
+      display:flex;
+      align-items:center;
+      justify-content:flex-start;
+      gap:.4rem;
+      min-width:0;
+      cursor:pointer;
+    }
     .consigne-card__value {
-      flex:0 0 auto;
       display:inline-flex;
       align-items:center;
       gap:.25rem;
@@ -596,12 +608,12 @@
       font-weight:500;
     }
     .consigne-card__aside {
+      grid-area:aside;
       display:flex;
       align-items:center;
       gap:.5rem;
-      flex:0 0 auto;
       justify-content:flex-end;
-      margin-left:auto;
+      justify-self:end;
     }
     .consigne-card__aside > * {
       flex-shrink:0;
@@ -611,20 +623,21 @@
     }
     @media (max-width: 640px) {
       .consigne-card__header {
-        flex-wrap:wrap;
+        grid-template-columns:minmax(0,1fr) auto;
+        grid-template-areas:
+          "title aside"
+          "meta aside";
         align-items:flex-start;
-        gap:.5rem;
+      }
+      .consigne-card__meta {
+        flex-direction:column;
+        align-items:flex-start;
+        gap:.35rem;
       }
       .consigne-card__value {
-        order:3;
         width:100%;
-        justify-content:flex-start;
         max-width:100%;
-      }
-      .consigne-card__aside {
-        margin-left:0;
-        width:100%;
-        justify-content:flex-end;
+        justify-content:flex-start;
       }
     }
     .consigne-menu {

--- a/modes.js
+++ b/modes.js
@@ -1925,6 +1925,24 @@ function initializeCollapsibleCard(card, { defaultOpen = false } = {}) {
     event.stopPropagation();
   }, { passive: true });
 
+  const metaToggle = card.querySelector("[data-consigne-meta]");
+  if (metaToggle) {
+    metaToggle.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      open();
+    });
+    metaToggle.addEventListener("pointerdown", (event) => {
+      event.stopPropagation();
+    });
+    metaToggle.addEventListener("mousedown", (event) => {
+      event.stopPropagation();
+    });
+    metaToggle.addEventListener("touchstart", (event) => {
+      event.stopPropagation();
+    }, { passive: true });
+  }
+
   if (defaultOpen) {
     requestAnimationFrame(() => {
       open();
@@ -2865,9 +2883,11 @@ async function renderPractice(ctx, root, _opts = {}) {
         <div class="consigne-card__header">
           <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
             <span class="consigne-card__title">${escapeHtml(c.text)}</span>
+          </button>
+          <div class="consigne-card__meta" data-consigne-meta>
             <span class="consigne-card__value" data-consigne-value></span>
             ${prioChip(Number(c.priority) || 2)}
-          </button>
+          </div>
           <div class="consigne-card__aside">
             ${srBadge(c)}
             ${consigneActions()}
@@ -3302,9 +3322,11 @@ async function renderDaily(ctx, root, opts = {}) {
       <div class="consigne-card__header">
         <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
           <span class="consigne-card__title">${escapeHtml(item.text)}</span>
+        </button>
+        <div class="consigne-card__meta" data-consigne-meta>
           <span class="consigne-card__value" data-consigne-value></span>
           ${prioChip(Number(item.priority) || 2)}
-        </button>
+        </div>
         <div class="consigne-card__aside">
           ${srBadge(item)}
           ${consigneActions()}


### PR DESCRIPTION
## Summary
- rework the consigne card header CSS into a three-column grid on desktop with stacked meta section on mobile
- introduce a dedicated meta wrapper in generated markup so the value and priority chip align with the new layout
- keep the value area interactive by wiring it to the existing picker toggle logic

## Testing
- Manual verification in browser at 360px viewport

------
https://chatgpt.com/codex/tasks/task_e_68dd93a5d6c8833388ab541beb45348f