### PR TITLE
Refactorise l’entête des cartes de consigne

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,21 +533,18 @@
       box-shadow:0 1px 0 rgba(15,23,42,.08);
     }
     .consigne-card__header {
-      display:grid;
-      grid-template-columns:minmax(0,1fr) auto auto;
-      grid-template-areas:"title meta aside";
+      display:flex;
+      flex-wrap:wrap;
       align-items:center;
-      column-gap:.75rem;
-      row-gap:.35rem;
+      gap:.3rem .45rem;
       min-height:2.5rem;
     }
     .consigne-card__toggle {
-      grid-area:title;
-      display:flex;
+      display:inline-flex;
       align-items:center;
-      gap:.5rem;
       justify-content:flex-start;
-      width:100%;
+      gap:.45rem;
+      flex:1 1 12rem;
       min-width:0;
       background:none;
       border:none;
@@ -557,6 +554,7 @@
       color:inherit;
       text-align:left;
       cursor:pointer;
+      flex-wrap:wrap;
     }
     .consigne-card__toggle::after {
       content:"▾";
@@ -579,12 +577,11 @@
       min-width:0;
       word-break:break-word;
     }
-    .consigne-card__meta {
-      grid-area:meta;
-      display:flex;
+    .consigne-card__inline-meta {
+      display:inline-flex;
       align-items:center;
-      justify-content:flex-start;
-      gap:.4rem;
+      gap:.3rem;
+      flex:0 0 auto;
       min-width:0;
       cursor:pointer;
     }
@@ -607,15 +604,14 @@
       color:var(--muted);
       font-weight:500;
     }
-    .consigne-card__aside {
-      grid-area:aside;
-      display:flex;
+    .consigne-card__inline-tools {
+      display:inline-flex;
       align-items:center;
-      gap:.5rem;
-      justify-content:flex-end;
-      justify-self:end;
+      gap:.3rem;
+      flex:0 0 auto;
+      flex-wrap:wrap;
     }
-    .consigne-card__aside > * {
+    .consigne-card__inline-tools > * {
       flex-shrink:0;
     }
     .consigne-card__field-store {
@@ -623,19 +619,14 @@
     }
     @media (max-width: 640px) {
       .consigne-card__header {
-        grid-template-columns:minmax(0,1fr) auto;
-        grid-template-areas:
-          "title aside"
-          "meta aside";
         align-items:flex-start;
+        gap:.35rem .5rem;
       }
-      .consigne-card__meta {
-        flex-direction:column;
-        align-items:flex-start;
-        gap:.35rem;
+      .consigne-card__inline-tools {
+        gap:.3rem;
       }
       .consigne-card__value {
-        width:100%;
+        width:auto;
         max-width:100%;
         justify-content:flex-start;
       }
@@ -678,7 +669,7 @@
     .consigne-picker__options {
       display:flex;
       flex-direction:column;
-      gap:.35rem;
+      gap:.3rem;
     }
     .consigne-picker__option {
       display:flex;

--- a/modes.js
+++ b/modes.js
@@ -1653,7 +1653,8 @@ function updateConsigneValueDisplay(card) {
   const state = consigneFieldStates.get(card);
   if (!state) return;
   const { definition, field } = state;
-  const display = card.querySelector("[data-consigne-value]");
+  const display = card.querySelector(".consigne-card__inline-meta [data-consigne-value]")
+    || card.querySelector("[data-consigne-value]");
   if (!display) return;
   const value = field ? field.value : definition.value;
   const label = formatConsigneValue(definition, value);
@@ -2883,12 +2884,12 @@ async function renderPractice(ctx, root, _opts = {}) {
         <div class="consigne-card__header">
           <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
             <span class="consigne-card__title">${escapeHtml(c.text)}</span>
+            <span class="consigne-card__inline-meta" data-consigne-meta>
+              <span class="consigne-card__value" data-consigne-value></span>
+              ${prioChip(Number(c.priority) || 2)}
+            </span>
           </button>
-          <div class="consigne-card__meta" data-consigne-meta>
-            <span class="consigne-card__value" data-consigne-value></span>
-            ${prioChip(Number(c.priority) || 2)}
-          </div>
-          <div class="consigne-card__aside">
+          <div class="consigne-card__inline-tools">
             ${srBadge(c)}
             ${consigneActions()}
           </div>
@@ -3016,12 +3017,12 @@ async function renderPractice(ctx, root, _opts = {}) {
       const parentCard = makeItem(group.consigne, { isChild: false });
       if (group.children.length) {
         parentCard.classList.add("consigne-card--has-children");
-        const aside = parentCard.querySelector(".consigne-card__aside");
-        if (aside) {
+        const tools = parentCard.querySelector(".consigne-card__inline-tools");
+        if (tools) {
           const badge = document.createElement("span");
           badge.className = "consigne-card__child-count";
           badge.textContent = `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`;
-          aside.prepend(badge);
+          tools.prepend(badge);
         }
         const existingContainer = parentCard.querySelector(".consigne-card__children");
         const childrenContainer = existingContainer || document.createElement("div");
@@ -3322,12 +3323,12 @@ async function renderDaily(ctx, root, opts = {}) {
       <div class="consigne-card__header">
         <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
           <span class="consigne-card__title">${escapeHtml(item.text)}</span>
+          <span class="consigne-card__inline-meta" data-consigne-meta>
+            <span class="consigne-card__value" data-consigne-value></span>
+            ${prioChip(Number(item.priority) || 2)}
+          </span>
         </button>
-        <div class="consigne-card__meta" data-consigne-meta>
-          <span class="consigne-card__value" data-consigne-value></span>
-          ${prioChip(Number(item.priority) || 2)}
-        </div>
-        <div class="consigne-card__aside">
+        <div class="consigne-card__inline-tools">
           ${srBadge(item)}
           ${consigneActions()}
         </div>
@@ -3451,12 +3452,12 @@ async function renderDaily(ctx, root, opts = {}) {
     const parentCard = renderItemCard(group.consigne, { isChild: false });
     if (group.children.length) {
       parentCard.classList.add("consigne-card--has-children");
-      const aside = parentCard.querySelector(".consigne-card__aside");
-      if (aside) {
+      const tools = parentCard.querySelector(".consigne-card__inline-tools");
+      if (tools) {
         const badge = document.createElement("span");
         badge.className = "consigne-card__child-count";
         badge.textContent = `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`;
-        aside.prepend(badge);
+        tools.prepend(badge);
       }
       const existingChildren = parentCard.querySelector(".consigne-card__children");
       const childrenContainer = existingChildren || document.createElement("div");


### PR DESCRIPTION
## Summary
- restructure le markup des cartes de consigne pour intégrer les métadonnées et outils inline
- met à jour les rendus pratique et journalier pour utiliser le nouveau conteneur d’outils et le badge de sous-consignes
- remplace la grille CSS par un flux flex/inline afin d’aligner valeur, sablier et menu sur une disposition fluide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de29dfeab883339389929d5684dbf8