### PR TITLE
Adjust consigne header layout for inline controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,18 +533,21 @@
       box-shadow:0 1px 0 rgba(15,23,42,.08);
     }
     .consigne-card__header {
+      min-height:2.5rem;
+    }
+    .consigne-card__header-row {
       display:flex;
       flex-wrap:wrap;
       align-items:center;
-      gap:.3rem .45rem;
-      min-height:2.5rem;
+      gap:.35rem .45rem;
+      width:100%;
     }
     .consigne-card__toggle {
       display:inline-flex;
       align-items:center;
       justify-content:flex-start;
       gap:.45rem;
-      flex:1 1 12rem;
+      flex:1 1 auto;
       min-width:0;
       background:none;
       border:none;
@@ -604,26 +607,26 @@
       color:var(--muted);
       font-weight:500;
     }
-    .consigne-card__inline-tools {
+    .consigne-card__inline-actions {
       display:inline-flex;
       align-items:center;
       gap:.3rem;
       flex:0 0 auto;
       flex-wrap:wrap;
     }
-    .consigne-card__inline-tools > * {
+    .consigne-card__inline-actions > * {
       flex-shrink:0;
     }
     .consigne-card__field-store {
       display:none;
     }
     @media (max-width: 640px) {
-      .consigne-card__header {
+      .consigne-card__header-row {
         align-items:flex-start;
-        gap:.35rem .5rem;
+        gap:.3rem .5rem;
       }
-      .consigne-card__inline-tools {
-        gap:.3rem;
+      .consigne-card__inline-actions {
+        gap:.25rem;
       }
       .consigne-card__value {
         width:auto;

--- a/modes.js
+++ b/modes.js
@@ -1654,7 +1654,7 @@ function updateConsigneValueDisplay(card) {
   const state = consigneFieldStates.get(card);
   if (!state) return;
   const { definition, field } = state;
-  const display = card.querySelector(".consigne-card__inline-meta [data-consigne-value]")
+  const display = card.querySelector("[data-consigne-meta] [data-consigne-value]")
     || card.querySelector("[data-consigne-value]");
   if (!display) return;
   const value = field ? field.value : definition.value;
@@ -2884,16 +2884,18 @@ async function renderPractice(ctx, root, _opts = {}) {
       }
       el.innerHTML = `
         <div class="consigne-card__header">
-          <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
-            <span class="consigne-card__title">${escapeHtml(c.text)}</span>
-            <span class="consigne-card__inline-meta" data-consigne-meta>
-              <span class="consigne-card__value" data-consigne-value></span>
-              ${priority.accessible}
-            </span>
-          </button>
-          <div class="consigne-card__inline-tools">
-            ${srBadge(c)}
-            ${consigneActions()}
+          <div class="consigne-card__header-row">
+            <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
+              <span class="consigne-card__title">${escapeHtml(c.text)}</span>
+              <span class="consigne-card__inline-meta" data-consigne-meta>
+                <span class="consigne-card__value" data-consigne-value></span>
+                ${priority.accessible}
+              </span>
+            </button>
+            <div class="consigne-card__inline-actions" data-consigne-inline-actions>
+              ${srBadge(c)}
+              ${consigneActions()}
+            </div>
           </div>
         </div>
       `;
@@ -3026,7 +3028,7 @@ async function renderPractice(ctx, root, _opts = {}) {
       const parentCard = makeItem(group.consigne, { isChild: false });
       if (group.children.length) {
         parentCard.classList.add("consigne-card--has-children");
-        const tools = parentCard.querySelector(".consigne-card__inline-tools");
+        const tools = parentCard.querySelector(".consigne-card__inline-actions");
         if (tools) {
           const badge = document.createElement("span");
           badge.className = "consigne-card__child-count";
@@ -3331,16 +3333,18 @@ async function renderDaily(ctx, root, opts = {}) {
     }
     itemCard.innerHTML = `
       <div class="consigne-card__header">
-        <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
-          <span class="consigne-card__title">${escapeHtml(item.text)}</span>
-          <span class="consigne-card__inline-meta" data-consigne-meta>
-            <span class="consigne-card__value" data-consigne-value></span>
-            ${priority.accessible}
-          </span>
-        </button>
-        <div class="consigne-card__inline-tools">
-          ${srBadge(item)}
-          ${consigneActions()}
+        <div class="consigne-card__header-row">
+          <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
+            <span class="consigne-card__title">${escapeHtml(item.text)}</span>
+            <span class="consigne-card__inline-meta" data-consigne-meta>
+              <span class="consigne-card__value" data-consigne-value></span>
+              ${priority.accessible}
+            </span>
+          </button>
+          <div class="consigne-card__inline-actions" data-consigne-inline-actions>
+            ${srBadge(item)}
+            ${consigneActions()}
+          </div>
         </div>
       </div>
     `;
@@ -3469,7 +3473,7 @@ async function renderDaily(ctx, root, opts = {}) {
     const parentCard = renderItemCard(group.consigne, { isChild: false });
     if (group.children.length) {
       parentCard.classList.add("consigne-card--has-children");
-      const tools = parentCard.querySelector(".consigne-card__inline-tools");
+      const tools = parentCard.querySelector(".consigne-card__inline-actions");
       if (tools) {
         const badge = document.createElement("span");
         badge.className = "consigne-card__child-count";


### PR DESCRIPTION
## Summary
- refactor practice and daily consigne cards to render value, SR toggle, and menu within the same inline header flow
- update consigne header styles for the new inline-flex layout and responsive behaviour
- align the value display helper with the new selectors

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68de2e785dc083339c60fca63286e34a