### PR TITLE
Simplify consigne headers and move SR control into menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -551,14 +551,13 @@
     }
     .consigne-card__header-row {
       display:flex;
-      flex-wrap:wrap;
-      align-items:center;
-      gap:.35rem .45rem;
+      align-items:flex-start;
+      gap:.35rem;
       width:100%;
     }
     .consigne-card__toggle {
-      display:inline-flex;
-      align-items:center;
+      display:flex;
+      align-items:flex-start;
       justify-content:flex-start;
       gap:.45rem;
       flex:1 1 auto;
@@ -571,7 +570,6 @@
       color:inherit;
       text-align:left;
       cursor:pointer;
-      flex-wrap:wrap;
     }
     .consigne-card__toggle::after {
       content:"▾";
@@ -579,6 +577,7 @@
       margin-left:auto;
       color:var(--muted);
       transition:transform .2s ease, color .2s ease;
+      padding-left:.35rem;
     }
     .consigne-card--picker-open .consigne-card__toggle::after {
       transform:rotate(180deg);
@@ -590,62 +589,26 @@
       border-radius:.5rem;
     }
     .consigne-card__title {
+      display:flex;
+      align-items:center;
+      gap:.45rem;
+      flex:1 1 auto;
+      min-width:0;
+      line-height:1.35;
+      word-break:break-word;
+      flex-wrap:wrap;
+    }
+    .consigne-card__title-text {
       flex:1 1 auto;
       min-width:0;
       word-break:break-word;
-    }
-    .consigne-card__inline-meta {
-      display:inline-flex;
-      align-items:center;
-      gap:.3rem;
-      flex:0 0 auto;
-      min-width:0;
-      cursor:pointer;
-    }
-    .consigne-card__value {
-      display:inline-flex;
-      align-items:center;
-      gap:.25rem;
-      font-size:.85rem;
-      padding:.1rem .4rem;
-      border-radius:.5rem;
-      background:rgba(15,23,42,.06);
-      color:#0f172a;
-      max-width:12rem;
-      white-space:nowrap;
-      text-overflow:ellipsis;
-      overflow:hidden;
-    }
-    .consigne-card__value--placeholder {
-      background:transparent;
-      color:var(--muted);
-      font-weight:500;
-    }
-    .consigne-card__inline-actions {
-      display:inline-flex;
-      align-items:center;
-      gap:.3rem;
-      flex:0 0 auto;
-      flex-wrap:wrap;
-    }
-    .consigne-card__inline-actions > * {
-      flex-shrink:0;
     }
     .consigne-card__field-store {
       display:none;
     }
     @media (max-width: 640px) {
       .consigne-card__header-row {
-        align-items:flex-start;
-        gap:.3rem .5rem;
-      }
-      .consigne-card__inline-actions {
-        gap:.25rem;
-      }
-      .consigne-card__value {
-        width:auto;
-        max-width:100%;
-        justify-content:flex-start;
+        gap:.3rem;
       }
     }
     .consigne-menu {


### PR DESCRIPTION
## Summary
- refactor practice and daily consigne cards to keep only the title and context-menu trigger in the header
- move the spaced-repetition toggle into the menu and expose value summaries as tooltips instead of inline meta blocks
- clean up the associated card CSS so the header stays on a single row across breakpoints

## Testing
- manual verification via Playwright preview

------
https://chatgpt.com/codex/tasks/task_e_68de34d9c4c48333a1cab606aa16315f