### PR TITLE
Neutralize high priority background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,8 +886,8 @@
       vertical-align:middle;
     }
     .priority-surface-high {
-      background:#fffbeb;
-      border:1px solid rgba(250,204,21,.35);
+      background:#ffffff;
+      border:1px solid #e2e8f0;
       box-shadow:none;
     }
     .priority-surface-medium {
@@ -901,8 +901,8 @@
     }
 
     .consigne-card.priority-surface-high {
-      background:#fffbeb;
-      border:1px solid rgba(250,204,21,.35);
+      background:#ffffff;
+      border:1px solid #e2e8f0;
       box-shadow:none;
     }
     .consigne-card.priority-surface-low {


### PR DESCRIPTION
## Summary
- align the high-priority surface styles with the neutral treatment used for medium priority
- keep the priority chip as the sole visual indicator of high priority across cards

## Testing
- manual verification in daily and practice views

------
https://chatgpt.com/codex/tasks/task_e_68de4e5418e0833384ec6dabb9fd75ec