### PR TITLE
Compact daily cards spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,7 +490,7 @@
     }
     .daily-category__items {
       display:grid;
-      gap:.25rem;
+      gap:.12rem;
       flex:1 1 auto;
     }
     .daily-category__low {
@@ -515,21 +515,21 @@
     .daily-category__items--nested {
       margin-top:.75rem;
       display:grid;
-      gap:.25rem;
+      gap:.12rem;
     }
     .consigne-card {
       position:relative;
       background:var(--card-bg);
-      border:1px solid rgba(148,163,184,.26);
-      border-radius:.85rem;
-      padding:.4rem .6rem;
-      box-shadow:0 1px 2px rgba(15,23,42,.08);
+      border:1px solid rgba(148,163,184,.3);
+      border-radius:.65rem;
+      padding:.25rem .45rem;
+      box-shadow:0 1px 1px rgba(15,23,42,.08);
       transition:background-color .2s ease, border-color .2s ease, background-image .2s ease, box-shadow .2s ease;
       overflow:visible;
     }
     .consigne-card--compact {
-      padding:.35rem .5rem;
-      border-radius:.7rem;
+      padding:.22rem .35rem;
+      border-radius:.55rem;
       box-shadow:0 1px 0 rgba(15,23,42,.08);
     }
     .consigne-card--stacked::before {
@@ -544,9 +544,26 @@
       transition:opacity .2s ease;
       pointer-events:none;
     }
+    .consigne-card::after {
+      content:"";
+      position:absolute;
+      left:.4rem;
+      right:.4rem;
+      bottom:-.05rem;
+      height:1px;
+      background:linear-gradient(90deg, rgba(148,163,184,.08) 0%, rgba(148,163,184,.3) 50%, rgba(148,163,184,.08) 100%);
+      opacity:0;
+      transition:opacity .2s ease;
+      pointer-events:none;
+    }
     .daily-category__items .consigne-card--stacked:not(:first-child)::before,
     .daily-category__items--nested .consigne-card--stacked:not(:first-child)::before,
     .consigne-card__children-list .consigne-card--stacked:not(:first-child)::before {
+      opacity:1;
+    }
+    .daily-category__items .consigne-card:not(:last-child)::after,
+    .daily-category__items--nested .consigne-card:not(:last-child)::after,
+    .consigne-group > .consigne-card:not(:last-child)::after {
       opacity:1;
     }
     .consigne-card__header-row {
@@ -800,9 +817,9 @@
 
     .consigne-group {
       display:grid;
-      gap:.4rem;
-      padding:.35rem 0;
-      border-bottom:1px solid rgba(148,163,184,.2);
+      gap:.15rem;
+      padding:.25rem 0;
+      border-bottom:1px solid rgba(148,163,184,.24);
     }
     .consigne-group:last-child {
       border-bottom:none;


### PR DESCRIPTION
## Summary
- reduce the gaps within daily categories and consigne groups to tighten the layout
- shrink consigne card padding and border radii while keeping borders legible
- add a subtle separator line to maintain the list feel despite the denser spacing

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68de4fc07ba48333be4a89ca43c1ae58