### PR TITLE
Convert consigne child list into collapsible details

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,10 +455,11 @@
         padding:.9rem .6rem 1rem;
       }
       .consigne-card__children {
-        padding:.25rem 0 .65rem;
+        padding:.2rem 0 .55rem;
       }
       .consigne-card__children-list {
         padding-left:.5rem;
+        gap:.5rem;
       }
       .consigne-card {
         padding:.4rem .6rem;
@@ -821,11 +822,11 @@
       padding:0;
     }
     .consigne-card__children {
-      margin-top:1rem;
-      padding-top:.85rem;
-      border-top:1px dashed rgba(148,163,184,.35);
+      margin-top:.75rem;
+      padding-top:.5rem;
+      border-top:1px solid rgba(148,163,184,.25);
       display:grid;
-      gap:.75rem;
+      gap:.5rem;
       width:100%;
     }
     .consigne-card__children-label {
@@ -835,12 +836,38 @@
       display:flex;
       align-items:center;
       gap:.35rem;
+      cursor:pointer;
+      user-select:none;
+      list-style:none;
+      padding:.2rem 0;
+      border-radius:.4rem;
+      transition:color .2s ease;
+    }
+    .consigne-card__children-label::before {
+      content:"▸";
+      font-size:.8rem;
+      line-height:1;
+      transition:transform .2s ease;
+      margin-right:.25rem;
+      display:inline-block;
+    }
+    .consigne-card__children-label::-webkit-details-marker {
+      display:none;
+    }
+    .consigne-card__children[open] .consigne-card__children-label::before {
+      transform:rotate(90deg);
+    }
+    .consigne-card__children-label:hover {
+      color:var(--accent-600);
+    }
+    .consigne-card__children-label:focus-visible {
+      outline:2px solid var(--accent-400);
+      outline-offset:2px;
     }
     .consigne-card__children-list {
       display:grid;
-      gap:.75rem;
-      padding-left:1rem;
-      border-left:2px solid rgba(148,163,184,.2);
+      gap:.6rem;
+      padding-left:.85rem;
     }
     .consigne-card__children-list > .consigne-card {
       margin:0;

--- a/modes.js
+++ b/modes.js
@@ -3090,14 +3090,19 @@ async function renderPractice(ctx, root, _opts = {}) {
           titleNode.appendChild(badge);
         }
         const existingContainer = parentCard.querySelector(".consigne-card__children");
-        const childrenContainer = existingContainer || document.createElement("div");
+        const isDetailsElement =
+          typeof HTMLDetailsElement !== "undefined" && existingContainer instanceof HTMLDetailsElement;
+        const childrenContainer = isDetailsElement
+          ? existingContainer
+          : document.createElement("details");
         childrenContainer.className = "consigne-card__children";
+        childrenContainer.removeAttribute("open");
         if (!existingContainer) {
           parentCard.appendChild(childrenContainer);
         } else {
           childrenContainer.innerHTML = "";
         }
-        const label = document.createElement("div");
+        const label = document.createElement("summary");
         label.className = "consigne-card__children-label";
         label.textContent = group.children.length > 1
           ? `Sous-consignes (${group.children.length})`
@@ -3538,14 +3543,19 @@ async function renderDaily(ctx, root, opts = {}) {
         titleNode.appendChild(badge);
       }
       const existingChildren = parentCard.querySelector(".consigne-card__children");
-      const childrenContainer = existingChildren || document.createElement("div");
+      const hasDetailsElement =
+        typeof HTMLDetailsElement !== "undefined" && existingChildren instanceof HTMLDetailsElement;
+      const childrenContainer = hasDetailsElement
+        ? existingChildren
+        : document.createElement("details");
       childrenContainer.className = "consigne-card__children";
+      childrenContainer.removeAttribute("open");
       if (!existingChildren) {
         parentCard.appendChild(childrenContainer);
       } else {
         childrenContainer.innerHTML = "";
       }
-      const label = document.createElement("div");
+      const label = document.createElement("summary");
       label.className = "consigne-card__children-label";
       label.textContent = group.children.length > 1
         ? `Sous-consignes (${group.children.length})`


### PR DESCRIPTION
## Summary
- replace the child consigne wrapper with a <details>/<summary> element so sub-consignes collapse by default in practice and daily renders
- refresh the consigne child styles to match the new summary trigger with tighter spacing and simplified borders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de5596c4688333b4ded0a5097e06be