### PR TITLE
Affiner l'espacement des sous-consignes

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,10 +439,14 @@
         width:100%;
       }
       .consigne-card__children {
+        margin-top:.45rem;
         padding-inline:0;
+        padding-top:.25rem;
+        gap:.3rem;
       }
       .consigne-card__children-list {
-        padding-left:.65rem;
+        padding-left:.55rem;
+        gap:.35rem;
       }
     }
     @media (max-width: 360px) {
@@ -455,11 +459,13 @@
         padding:.9rem .6rem 1rem;
       }
       .consigne-card__children {
-        padding:.2rem 0 .55rem;
+        margin-top:.4rem;
+        padding:.15rem 0 .45rem;
+        gap:.28rem;
       }
       .consigne-card__children-list {
-        padding-left:.5rem;
-        gap:.5rem;
+        padding-left:.45rem;
+        gap:.3rem;
       }
       .consigne-card {
         padding:.4rem .6rem;
@@ -822,11 +828,10 @@
       padding:0;
     }
     .consigne-card__children {
-      margin-top:.75rem;
-      padding-top:.5rem;
-      border-top:1px solid rgba(148,163,184,.25);
+      margin-top:.5rem;
+      padding-top:.3rem;
       display:grid;
-      gap:.5rem;
+      gap:.35rem;
       width:100%;
     }
     .consigne-card__children-label {
@@ -866,8 +871,8 @@
     }
     .consigne-card__children-list {
       display:grid;
-      gap:.6rem;
-      padding-left:.85rem;
+      gap:.4rem;
+      padding-left:.65rem;
     }
     .consigne-card__children-list > .consigne-card {
       margin:0;


### PR DESCRIPTION
## Summary
- réduire les marges et espacements du bloc `.consigne-card__children` pour compacter le résumé et son contenu
- ajuster l'espacement et l'indentation des listes `.consigne-card__children-list`, y compris sur mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de587afa848333a12b4c2208806024