### PR TITLE
Reduce spacing in daily cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,11 +467,11 @@
         padding-left:.45rem;
         gap:.3rem;
       }
-      .consigne-card {
-        padding:.4rem .6rem;
+      .consigne-card { 
+        padding:.2rem .55rem;
       }
       .consigne-card--compact {
-        padding:.3rem .5rem;
+        padding:.14rem .4rem;
       }
       .tab {
         padding:.4rem .65rem;
@@ -497,12 +497,12 @@
     }
     .daily-category__items {
       display:grid;
-      gap:.12rem;
+      gap:0;
       flex:1 1 auto;
     }
     .daily-category__low {
-      margin-top:.25rem;
-      padding-top:1rem;
+      margin-top:.35rem;
+      padding-top:.95rem;
     }
     .daily-category__low-summary {
       list-style:none;
@@ -522,20 +522,20 @@
     .daily-category__items--nested {
       margin-top:.75rem;
       display:grid;
-      gap:.12rem;
+      gap:0;
     }
     .consigne-card {
       position:relative;
       background:var(--card-bg);
       border:1px solid rgba(148,163,184,.3);
       border-radius:.65rem;
-      padding:.18rem .45rem;
+      padding:.12rem .45rem;
       box-shadow:0 1px 1px rgba(15,23,42,.08);
       transition:background-color .2s ease, border-color .2s ease, background-image .2s ease, box-shadow .2s ease;
       overflow:visible;
     }
     .consigne-card--compact {
-      padding:.15rem .35rem;
+      padding:.1rem .35rem;
       border-radius:.55rem;
       box-shadow:0 1px 0 rgba(15,23,42,.08);
     }


### PR DESCRIPTION
## Summary
- remove residual gaps between daily cards and nested stacks
- tighten card padding across breakpoints to lower height while keeping compact variants aligned
- adjust low-priority section spacing to maintain consistent separation after gap updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5ac424208333b98f42c833357ff0