### PR TITLE
Fix priority star placement in consigne titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,9 +593,13 @@
       flex-wrap:wrap;
     }
     .consigne-card__title-text {
+      display:inline-flex;
+      align-items:center;
+      gap:.25rem;
       flex:1 1 auto;
       min-width:0;
       word-break:break-word;
+      flex-wrap:wrap;
     }
     .consigne-card__field-store {
       display:none;
@@ -924,7 +928,7 @@
       align-items:center;
       justify-content:center;
       margin-left:0;
-      margin-right:.35rem;
+      margin-right:0;
       font-size:.95rem;
       line-height:1;
       color:#facc15;

--- a/modes.js
+++ b/modes.js
@@ -2961,7 +2961,9 @@ async function renderPractice(ctx, root, _opts = {}) {
       if (tone === "high" && priority.symbol) {
         const title = el.querySelector(".consigne-card__title");
         if (title) {
-          title.insertAdjacentHTML("afterbegin", priority.symbol);
+          const label = title.querySelector(".consigne-card__title-text");
+          const target = label ?? title;
+          target.insertAdjacentHTML("afterbegin", priority.symbol);
         }
       }
 
@@ -3418,7 +3420,9 @@ async function renderDaily(ctx, root, opts = {}) {
     if (tone === "high" && priority.symbol) {
       const title = itemCard.querySelector(".consigne-card__title");
       if (title) {
-        title.insertAdjacentHTML("afterbegin", priority.symbol);
+        const label = title.querySelector(".consigne-card__title-text");
+        const target = label ?? title;
+        target.insertAdjacentHTML("afterbegin", priority.symbol);
       }
     }
 


### PR DESCRIPTION
## Summary
- insert the priority icon directly into the consigne title text with a fallback when the label element is missing
- adjust the title text layout and priority chip spacing so the icon and label sit compactly together

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68de601574d88333a7ffa03ae2e5fd69