### PR TITLE
Keep priority icon aligned with consigne titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,13 +593,15 @@
       flex-wrap:wrap;
     }
     .consigne-card__title-text {
-      display:inline-flex;
+      display:flex;
+      flex-wrap:nowrap;
       align-items:center;
       gap:.25rem;
+    }
+    .consigne-card__title-label {
       flex:1 1 auto;
       min-width:0;
       word-break:break-word;
-      flex-wrap:wrap;
     }
     .consigne-card__field-store {
       display:none;
@@ -929,6 +931,7 @@
       justify-content:center;
       margin-left:0;
       margin-right:0;
+      flex:0 0 auto;
       font-size:.95rem;
       line-height:1;
       color:#facc15;

--- a/modes.js
+++ b/modes.js
@@ -2938,7 +2938,9 @@ async function renderPractice(ctx, root, _opts = {}) {
           <div class="consigne-card__header-row">
             <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
               <span class="consigne-card__title">
-                <span class="consigne-card__title-text">${escapeHtml(c.text)}</span>
+                <span class="consigne-card__title-text">
+                  <span class="consigne-card__title-label">${escapeHtml(c.text)}</span>
+                </span>
               </span>
               ${priority.accessible}
             </button>
@@ -2961,8 +2963,9 @@ async function renderPractice(ctx, root, _opts = {}) {
       if (tone === "high" && priority.symbol) {
         const title = el.querySelector(".consigne-card__title");
         if (title) {
-          const label = title.querySelector(".consigne-card__title-text");
-          const target = label ?? title;
+          const container = title.querySelector(".consigne-card__title-text");
+          const label = title.querySelector(".consigne-card__title-label");
+          const target = container ?? label ?? title;
           target.insertAdjacentHTML("afterbegin", priority.symbol);
         }
       }
@@ -3397,7 +3400,9 @@ async function renderDaily(ctx, root, opts = {}) {
         <div class="consigne-card__header-row">
           <button type="button" class="consigne-card__toggle" data-consigne-toggle aria-expanded="false">
             <span class="consigne-card__title">
-              <span class="consigne-card__title-text">${escapeHtml(item.text)}</span>
+              <span class="consigne-card__title-text">
+                <span class="consigne-card__title-label">${escapeHtml(item.text)}</span>
+              </span>
             </span>
             ${priority.accessible}
           </button>
@@ -3420,8 +3425,9 @@ async function renderDaily(ctx, root, opts = {}) {
     if (tone === "high" && priority.symbol) {
       const title = itemCard.querySelector(".consigne-card__title");
       if (title) {
-        const label = title.querySelector(".consigne-card__title-text");
-        const target = label ?? title;
+        const container = title.querySelector(".consigne-card__title-text");
+        const label = title.querySelector(".consigne-card__title-label");
+        const target = container ?? label ?? title;
         target.insertAdjacentHTML("afterbegin", priority.symbol);
       }
     }


### PR DESCRIPTION
## Summary
- wrap consigne titles in a dedicated label span so the priority icon can share a flex container
- update the practice and daily card templates to inject the priority star ahead of the new label slot
- adjust the title text and priority chip styles to keep the icon tight to the label across viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de62d62df48333a5c6ffd392f9b913