### PR TITLE
Set high priority consigne titles to brand blue

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,6 +592,10 @@
       word-break:break-word;
       flex-wrap:wrap;
     }
+    .priority-surface-high .consigne-card__title,
+    .priority-surface-high .consigne-card__title-label {
+      color:#2563eb;
+    }
     .consigne-card__title-text {
       display:flex;
       flex-wrap:nowrap;


### PR DESCRIPTION
## Summary
- ensure high priority consigne card titles and labels display with the intended blue text color
- keep the style active across responsive breakpoints by defining it alongside the base title rules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6e1400ec8333ba35c8329b57832d