### PR TITLE
Compact child badge label

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,8 +890,9 @@
     .consigne-card__child-count {
       display:inline-flex;
       align-items:center;
-      gap:.25rem;
-      padding:.15rem .5rem;
+      justify-content:center;
+      min-width:1.5rem;
+      padding:.15rem .4rem;
       border-radius:999px;
       border:1px solid rgba(148,163,184,.35);
       background:rgba(148,163,184,.12);

--- a/modes.js
+++ b/modes.js
@@ -3108,7 +3108,11 @@ async function renderPractice(ctx, root, _opts = {}) {
         if (titleNode) {
           const badge = document.createElement("span");
           badge.className = "consigne-card__child-count";
-          badge.textContent = `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`;
+          badge.textContent = `${group.children.length}`;
+          badge.setAttribute(
+            "aria-label",
+            `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`
+          );
           titleNode.appendChild(badge);
         }
         const existingContainer = parentCard.querySelector(".consigne-card__children");
@@ -3556,7 +3560,11 @@ async function renderDaily(ctx, root, opts = {}) {
       if (titleNode) {
         const badge = document.createElement("span");
         badge.className = "consigne-card__child-count";
-        badge.textContent = `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`;
+        badge.textContent = `${group.children.length}`;
+        badge.setAttribute(
+          "aria-label",
+          `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`
+        );
         titleNode.appendChild(badge);
       }
       const existingChildren = parentCard.querySelector(".consigne-card__children");


### PR DESCRIPTION
## Summary
- shorten child count badges to numeric content while keeping descriptive aria labels
- adjust badge styling so the compact content retains the intended appearance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de732bf1b48333b62f53fd13a7cc01