### PR TITLE
Remove unused child count badge from consigne cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,20 +887,6 @@
     .consigne-card__children-list > .consigne-card {
       margin:0;
     }
-    .consigne-card__child-count {
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      min-width:1.5rem;
-      padding:.15rem .4rem;
-      border-radius:999px;
-      border:1px solid rgba(148,163,184,.35);
-      background:rgba(148,163,184,.12);
-      font-size:.72rem;
-      font-weight:600;
-      color:#475569;
-      line-height:1.1;
-    }
     .consigne-card--child {
       margin-left:0;
       border-color:rgba(148,163,184,.28);

--- a/modes.js
+++ b/modes.js
@@ -3104,17 +3104,6 @@ async function renderPractice(ctx, root, _opts = {}) {
       const parentCard = makeItem(group.consigne, { isChild: false });
       if (group.children.length) {
         parentCard.classList.add("consigne-card--has-children");
-        const titleNode = parentCard.querySelector(".consigne-card__title");
-        if (titleNode) {
-          const badge = document.createElement("span");
-          badge.className = "consigne-card__child-count";
-          badge.textContent = `${group.children.length}`;
-          badge.setAttribute(
-            "aria-label",
-            `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`
-          );
-          titleNode.appendChild(badge);
-        }
         const existingContainer = parentCard.querySelector(".consigne-card__children");
         const isDetailsElement =
           typeof HTMLDetailsElement !== "undefined" && existingContainer instanceof HTMLDetailsElement;
@@ -3556,17 +3545,6 @@ async function renderDaily(ctx, root, opts = {}) {
     const parentCard = renderItemCard(group.consigne, { isChild: false });
     if (group.children.length) {
       parentCard.classList.add("consigne-card--has-children");
-      const titleNode = parentCard.querySelector(".consigne-card__title");
-      if (titleNode) {
-        const badge = document.createElement("span");
-        badge.className = "consigne-card__child-count";
-        badge.textContent = `${group.children.length}`;
-        badge.setAttribute(
-          "aria-label",
-          `${group.children.length} sous-consigne${group.children.length > 1 ? "s" : ""}`
-        );
-        titleNode.appendChild(badge);
-      }
       const existingChildren = parentCard.querySelector(".consigne-card__children");
       const hasDetailsElement =
         typeof HTMLDetailsElement !== "undefined" && existingChildren instanceof HTMLDetailsElement;


### PR DESCRIPTION
## Summary
- stop rendering the consigne child-count badge in both daily and practice views
- remove the unused child-count badge styles from the main HTML stylesheet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7493da088333955ba5ae488e3987