### PR TITLE
Adjust priority title color tone

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
     }
     .priority-surface-high .consigne-card__title,
     .priority-surface-high .consigne-card__title-label {
-      color:#2563eb;
+      color:#60a5fa;
     }
     .consigne-card__title-text {
       display:flex;


### PR DESCRIPTION
## Summary
- update the high priority consigne title and label color to a pastel blue to soften the emphasis
- confirmed responsive styles do not override the new tone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7c484b788333af3de7557d79e789