### PR TITLE
Ensure child consignes remain nested in parent cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,6 +442,7 @@
         gap:.65rem;
       }
       .consigne-card__children {
+        margin:.3rem -.45rem -.45rem;
         padding:.55rem .6rem;
         gap:.4rem;
       }
@@ -466,6 +467,7 @@
         gap:.55rem;
       }
       .consigne-card__children {
+        margin:.28rem -.55rem -.55rem;
         padding:.45rem .5rem;
         gap:.35rem;
       }
@@ -845,18 +847,16 @@
       gap:.75rem;
       padding:0;
     }
-    .consigne-group__children {
-      display:block;
-      width:100%;
-    }
     .consigne-card__children {
       display:grid;
       gap:.5rem;
       width:100%;
-      background:#f8fafc;
+      background:#fff;
       border:1px solid rgba(148,163,184,.28);
-      border-radius:.65rem;
-      padding:.65rem .75rem;
+      border-radius:.55rem;
+      margin:.35rem -.45rem -.45rem;
+      padding:.55rem .6rem;
+      box-shadow:0 6px 14px rgba(15,23,42,.08);
     }
     .consigne-card__children-label {
       font-size:.78rem;

--- a/modes.js
+++ b/modes.js
@@ -3128,10 +3128,7 @@ async function renderPractice(ctx, root, _opts = {}) {
         });
         childrenContainer.appendChild(label);
         childrenContainer.appendChild(list);
-        const childSection = document.createElement("div");
-        childSection.className = "consigne-group__children";
-        childSection.appendChild(childrenContainer);
-        wrapper.appendChild(childSection);
+        parentCard.appendChild(childrenContainer);
       }
       target.appendChild(wrapper);
     };
@@ -3570,10 +3567,7 @@ async function renderDaily(ctx, root, opts = {}) {
       });
       childrenContainer.appendChild(label);
       childrenContainer.appendChild(list);
-      const childSection = document.createElement("div");
-      childSection.className = "consigne-group__children";
-      childSection.appendChild(childrenContainer);
-      wrapper.appendChild(childSection);
+      parentCard.appendChild(childrenContainer);
     }
     target.appendChild(wrapper);
   };


### PR DESCRIPTION
## Summary
- append rendered child consignes directly to their parent cards in both practice and daily modes
- clean up the obsolete wrapper class and restyle the child details container to visually blend with the parent card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de82189c188333a9335a6cd99efbca