### PR TITLE
Refine styling of consigne children cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,16 +442,17 @@
         gap:.65rem;
       }
       .consigne-card__children {
-        margin:.3rem -.45rem -.45rem;
-        padding:.55rem .6rem;
-        gap:.4rem;
+        margin:.22rem -.3rem -.3rem;
+        padding:.3rem .4rem .4rem;
+        gap:.32rem;
       }
       .consigne-card__children-label {
         font-size:.76rem;
-        padding:.2rem .3rem;
       }
       .consigne-card__children-list {
-        gap:.4rem;
+        gap:.3rem;
+        margin:0;
+        padding:0;
       }
     }
     @media (max-width: 360px) {
@@ -467,15 +468,17 @@
         gap:.55rem;
       }
       .consigne-card__children {
-        margin:.28rem -.55rem -.55rem;
-        padding:.45rem .5rem;
-        gap:.35rem;
+        margin:.18rem -.32rem -.32rem;
+        padding:.28rem .35rem .35rem;
+        gap:.28rem;
       }
       .consigne-card__children-label {
         font-size:.74rem;
       }
       .consigne-card__children-list {
-        gap:.32rem;
+        gap:.26rem;
+        margin:0;
+        padding:0;
       }
       .consigne-card {
         padding:.2rem .55rem;
@@ -849,14 +852,12 @@
     }
     .consigne-card__children {
       display:grid;
-      gap:.5rem;
+      gap:.4rem;
       width:100%;
-      background:#fff;
-      border:1px solid rgba(148,163,184,.28);
-      border-radius:.55rem;
-      margin:.35rem -.45rem -.45rem;
-      padding:.55rem .6rem;
-      box-shadow:0 6px 14px rgba(15,23,42,.08);
+      background:rgba(148,163,184,.08);
+      border-radius:0 0 .55rem .55rem;
+      margin:.25rem -.35rem -.35rem;
+      padding:.35rem .45rem .45rem;
     }
     .consigne-card__children-label {
       font-size:.78rem;
@@ -868,13 +869,12 @@
       cursor:pointer;
       user-select:none;
       list-style:none;
-      padding:.25rem .35rem;
-      border-radius:.5rem;
-      transition:color .2s ease, background-color .2s ease;
+      padding:0;
+      transition:color .2s ease;
     }
     .consigne-card__children-label::before {
       content:"▸";
-      font-size:.8rem;
+      font-size:.68rem;
       line-height:1;
       transition:transform .2s ease;
       margin-right:.25rem;
@@ -887,8 +887,7 @@
       transform:rotate(90deg);
     }
     .consigne-card__children-label:hover {
-      color:#0f172a;
-      background:rgba(148,163,184,.15);
+      color:var(--accent-500);
     }
     .consigne-card__children-label:focus-visible {
       outline:2px solid var(--accent-400);
@@ -896,14 +895,17 @@
     }
     .consigne-card__children-list {
       display:grid;
-      gap:.5rem;
+      gap:.35rem;
+      margin:0;
+      padding:0;
     }
     .consigne-card__children-list > .consigne-card {
       margin:0;
     }
     .consigne-card--child {
       margin:0;
-      border-color:rgba(148,163,184,.26);
+      border:0;
+      background:transparent;
       box-shadow:none;
     }
 


### PR DESCRIPTION
## Summary
- soften the consigne children container with a tinted background, tighter spacing, and bottom-only rounding
- streamline child label styling with zero padding, text-based hover feedback, and a smaller chevron icon
- align children list spacing across breakpoints while clearing extra borders for embedded cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de84af829c8333a2ec4af41efc4528