### PR TITLE
Align nested consigne card margins with card padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
         gap:.65rem;
       }
       .consigne-card__children {
-        margin:.22rem -.3rem -.3rem;
+        margin:.22rem -.45rem -.3rem;
         padding:.3rem .4rem .4rem;
         gap:.32rem;
       }
@@ -468,7 +468,7 @@
         gap:.55rem;
       }
       .consigne-card__children {
-        margin:.18rem -.32rem -.32rem;
+        margin:.18rem -.55rem -.32rem;
         padding:.28rem .35rem .35rem;
         gap:.28rem;
       }
@@ -856,7 +856,7 @@
       width:100%;
       background:rgba(148,163,184,.08);
       border-radius:0 0 .55rem .55rem;
-      margin:.25rem -.35rem -.35rem;
+      margin:.25rem -.45rem -.35rem;
       padding:.35rem .45rem .45rem;
     }
     .consigne-card__children-label {


### PR DESCRIPTION
## Summary
- align the default and responsive margins of `.consigne-card__children` with the corresponding `.consigne-card` padding values so the gray strip remains flush across breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de86b837f48333bd0507403a8b7f6d