### PR TITLE
Align consigne child spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
         gap:.65rem;
       }
       .consigne-card__children {
-        margin:.22rem -.45rem -.3rem;
+        margin:0 -.45rem -.3rem;
         padding:.3rem .4rem .4rem;
         gap:.32rem;
       }
@@ -468,7 +468,7 @@
         gap:.55rem;
       }
       .consigne-card__children {
-        margin:.18rem -.55rem -.32rem;
+        margin:0 -.55rem -.32rem;
         padding:.28rem .35rem .35rem;
         gap:.28rem;
       }
@@ -856,8 +856,8 @@
       width:100%;
       background:rgba(148,163,184,.08);
       border-radius:0 0 .55rem .55rem;
-      margin:.25rem -.45rem -.35rem;
-      padding:.35rem .45rem .45rem;
+      margin:0 -.45rem -.35rem;
+      padding:.32rem .45rem .45rem;
     }
     .consigne-card__children-label {
       font-size:.78rem;


### PR DESCRIPTION
## Summary
- set the consigne child container margin-top to zero so the gray band meets the parent content
- align mobile breakpoint margins and adjust padding so spacing is consistent on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8995b9508333869117ce3f517a07