### PR TITLE
Refine consigne actions panel styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,21 +738,21 @@
     .consigne-actions__panel {
       position:absolute;
       right:0;
-      top:calc(100% + .45rem);
+      top:calc(100% + .25rem);
       display:flex;
       flex-direction:column;
       align-items:stretch;
       gap:.25rem;
-      min-width:11rem;
+      min-width:9rem;
       padding:.5rem;
       background:#fff;
-      border:1px solid rgba(148,163,184,.28);
-      border-radius:.9rem;
-      box-shadow:0 18px 40px rgba(15,23,42,.16);
-      z-index:30;
+      border:1px solid rgba(148,163,184,.35);
+      border-radius:.75rem;
+      box-shadow:0 10px 30px -12px rgba(15,23,42,.25);
+      z-index:10;
     }
     .consigne-actions__panel[hidden] {
-      display:none;
+      display:none !important;
     }
     .consigne-actions__panel .btn {
       width:100%;

--- a/modes.js
+++ b/modes.js
@@ -1362,8 +1362,7 @@ function consigneActions() {
       <div class="consigne-actions__panel js-actions-panel card"
            role="menu"
            aria-hidden="true"
-           hidden
-           style="position:absolute; right:0; top:calc(100% + .25rem); display:flex; flex-direction:column; align-items:stretch; gap:.25rem; min-width:9rem; padding:.5rem; background:#fff; border:1px solid rgba(148,163,184,.35); border-radius:.75rem; box-shadow:0 10px 30px -12px rgba(15,23,42,.25); z-index:10;">
+           hidden>
         ${actionBtn("Historique", "js-histo")}
         ${actionBtn("Modifier", "js-edit")}
         ${actionBtn("Décaler", "js-delay")}


### PR DESCRIPTION
## Summary
- remove inline layout styling from the consigne actions panel markup
- configure stylesheet rules for the panel, ensuring the hidden attribute forces it closed on load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11aebf6cc8333ba7e17d0af7f680a