### PR TITLE
Tighten spacing in daily checklist layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
         padding-inline:0;
       }
       .consigne-row {
-        padding:.75rem 0;
+        padding:.55rem 0;
       }
       .consigne-row--child {
         margin-left:.5rem;
@@ -463,10 +463,10 @@
         padding:.9rem .6rem 1rem;
       }
       .consigne-group__children {
-        padding:.25rem .55rem .7rem;
+        padding:.2rem .5rem .55rem;
       }
       .consigne-row {
-        padding:.65rem 0;
+        padding:.5rem 0;
       }
       .tab {
         padding:.4rem .65rem;
@@ -492,12 +492,12 @@
     }
     .daily-category__items {
       display:grid;
-      gap:1.25rem;
+      gap:.4rem;
       flex:1 1 auto;
     }
     .daily-category__low {
-      margin-top:.25rem;
-      padding-top:1rem;
+      margin-top:.2rem;
+      padding-top:.75rem;
     }
     .daily-category__low-summary {
       list-style:none;
@@ -515,9 +515,9 @@
       display:none;
     }
     .daily-category__items--nested {
-      margin-top:.75rem;
+      margin-top:.45rem;
       display:grid;
-      gap:1.1rem;
+      gap:.4rem;
     }
     ul.consigne-list {
       list-style:none;
@@ -535,7 +535,7 @@
       display:flex;
       flex-direction:column;
       gap:.65rem;
-      padding:.85rem 0;
+      padding:.6rem 0;
       border-top:1px solid rgba(148,163,184,.18);
       background:transparent;
       border-radius:0;
@@ -773,11 +773,11 @@
 
     .consigne-group {
       display:grid;
-      gap:.5rem;
+      gap:.35rem;
     }
     .consigne-group__children {
-      margin-top:-.25rem;
-      padding:.35rem .85rem .9rem;
+      margin-top:-.2rem;
+      padding:.25rem .75rem .7rem;
       border-radius:.85rem;
       background:rgba(148,163,184,.08);
       width:100%;
@@ -807,8 +807,8 @@
     }
     .consigne-group__list {
       display:grid;
-      gap:.75rem;
-      margin-top:.5rem;
+      gap:.5rem;
+      margin-top:.35rem;
     }
     .consigne-card--child {
       margin-left:1rem;


### PR DESCRIPTION
## Summary
- reduce the gaps between daily item grids to make the list more compact without losing readability
- trim vertical padding on consigne rows and groups to avoid stacked wrapper spacing
- update small-screen overrides to keep the denser layout consistent on mobile and desktop

## Testing
- python -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68e11d78177883339bea05e12334bc32