### PR TITLE
feat: differentiate likert statuses and pastel row styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,10 +536,18 @@
       flex-direction:column;
       gap:.65rem;
       padding:.6rem 0;
-      border-top:1px solid rgba(148,163,184,.18);
-      background:transparent;
+      --consigne-status-bg:transparent;
+      --consigne-status-border:rgba(148,163,184,.18);
+      --consigne-status-text:#0f172a;
+      --consigne-status-accent:#475569;
+      --consigne-status-color:#94a3b8;
+      --consigne-status-dot-shadow:rgba(148,163,184,.18);
+      border-top:1px solid var(--consigne-status-border, rgba(148,163,184,.18));
+      background:var(--consigne-status-bg, transparent);
+      color:var(--consigne-status-text, #0f172a);
       border-radius:0;
       box-shadow:none;
+      transition:background .2s ease, border-color .2s ease;
     }
     .consigne-row:first-child {
       border-top:none;
@@ -599,7 +607,7 @@
     .consigne-row__title {
       font-weight:600;
       font-size:.98rem;
-      color:#0f172a;
+      color:var(--consigne-status-text, #0f172a);
       word-break:break-word;
     }
     .consigne-row__meta {
@@ -616,8 +624,7 @@
       gap:.45rem;
       font-size:.8rem;
       font-weight:600;
-      color:#475569;
-      --consigne-status-color:#94a3b8;
+      color:var(--consigne-status-accent, #475569);
     }
     .consigne-row__summary {
       color:inherit;
@@ -630,55 +637,91 @@
       background:var(--consigne-status-color, #94a3b8);
       flex:none;
       transition:background .2s ease, box-shadow .2s ease, transform .2s ease;
-      box-shadow:0 0 0 3px rgba(148,163,184,.15);
+      box-shadow:0 0 0 3px var(--consigne-status-dot-shadow, rgba(148,163,184,.15));
     }
-    .consigne-row[data-status="ok"],
-    .consigne-status--ok {
+    .consigne-row[data-status="ok-strong"],
+    .consigne-row__status[data-status="ok-strong"],
+    .consigne-status--ok-strong {
+      --consigne-status-bg:#dcfce7;
+      --consigne-status-border:rgba(34,197,94,.28);
+      --consigne-status-text:#14532d;
+      --consigne-status-accent:#166534;
       --consigne-status-color:#16a34a;
+      --consigne-status-dot-shadow:rgba(34,197,94,.25);
+    }
+    .consigne-row[data-status="ok-soft"],
+    .consigne-row__status[data-status="ok-soft"],
+    .consigne-status--ok-soft {
+      --consigne-status-bg:#f0fdf4;
+      --consigne-status-border:rgba(74,222,128,.24);
+      --consigne-status-text:#166534;
+      --consigne-status-accent:#15803d;
+      --consigne-status-color:#4ade80;
+      --consigne-status-dot-shadow:rgba(74,222,128,.22);
     }
     .consigne-row[data-status="mid"],
-    .consigne-status--mid {
-      --consigne-status-color:#eab308;
-    }
-    .consigne-row[data-status="ko"],
-    .consigne-status--ko {
-      --consigne-status-color:#dc2626;
-    }
-    .consigne-row[data-status="na"],
-    .consigne-status--na {
-      --consigne-status-color:#94a3b8;
-    }
-    .consigne-row__status[data-status="ok"],
-    .consigne-status--ok {
-      color:#166534;
-    }
     .consigne-row__status[data-status="mid"],
     .consigne-status--mid {
-      color:#a16207;
+      --consigne-status-bg:#fefce8;
+      --consigne-status-border:rgba(234,179,8,.32);
+      --consigne-status-text:#854d0e;
+      --consigne-status-accent:#a16207;
+      --consigne-status-color:#eab308;
+      --consigne-status-dot-shadow:rgba(234,179,8,.24);
     }
-    .consigne-row__status[data-status="ko"],
-    .consigne-status--ko {
-      color:#991b1b;
+    .consigne-row[data-status="ko-soft"],
+    .consigne-row__status[data-status="ko-soft"],
+    .consigne-status--ko-soft {
+      --consigne-status-bg:#fef2f2;
+      --consigne-status-border:rgba(248,113,113,.28);
+      --consigne-status-text:#7f1d1d;
+      --consigne-status-accent:#b91c1c;
+      --consigne-status-color:#f87171;
+      --consigne-status-dot-shadow:rgba(248,113,113,.24);
     }
+    .consigne-row[data-status="ko-strong"],
+    .consigne-row__status[data-status="ko-strong"],
+    .consigne-status--ko-strong {
+      --consigne-status-bg:#fee2e2;
+      --consigne-status-border:rgba(220,38,38,.32);
+      --consigne-status-text:#7f1d1d;
+      --consigne-status-accent:#991b1b;
+      --consigne-status-color:#dc2626;
+      --consigne-status-dot-shadow:rgba(220,38,38,.26);
+    }
+    .consigne-row[data-status="na"],
     .consigne-row__status[data-status="na"],
     .consigne-status--na {
-      color:#475569;
+      --consigne-status-bg:#f8fafc;
+      --consigne-status-border:rgba(148,163,184,.22);
+      --consigne-status-text:#0f172a;
+      --consigne-status-accent:#475569;
+      --consigne-status-color:#94a3b8;
+      --consigne-status-dot-shadow:rgba(148,163,184,.2);
     }
-    .consigne-row__dot--ok {
+    .consigne-row__dot--ok-strong {
       background:#16a34a;
-      box-shadow:0 0 0 3px rgba(22,101,52,.2);
+      box-shadow:0 0 0 3px rgba(34,197,94,.25);
+    }
+    .consigne-row__dot--ok-soft {
+      background:#4ade80;
+      box-shadow:0 0 0 3px rgba(74,222,128,.22);
     }
     .consigne-row__dot--mid {
       background:#eab308;
-      box-shadow:0 0 0 3px rgba(161,98,7,.18);
+      box-shadow:0 0 0 3px rgba(234,179,8,.24);
     }
-    .consigne-row__dot--ko {
+    .consigne-row__dot--ko-soft {
+      background:#f87171;
+      box-shadow:0 0 0 3px rgba(248,113,113,.24);
+    }
+    .consigne-row__dot--ko-strong {
       background:#dc2626;
-      box-shadow:0 0 0 3px rgba(153,27,27,.2);
+      box-shadow:0 0 0 3px rgba(220,38,38,.26);
     }
     .consigne-row__dot--na {
       background:#94a3b8;
-      box-shadow:0 0 0 3px rgba(148,163,184,.18);
+      box-shadow:0 0 0 3px rgba(148,163,184,.2);
     }
     .consigne-row__body {
       overflow:hidden;
@@ -1109,9 +1152,11 @@
     .practice-dashboard__history-date-sub{ font-size:.75rem; color:#94a3b8; }
     .practice-dashboard__history-meta-row{ font-size:.75rem; color:#64748b; }
     .practice-dashboard__history-dot{ width:.75rem; height:.75rem; border-radius:999px; background:#94a3b8; flex:none; margin-top:.2rem; }
-    .practice-dashboard__history-dot--ok{ background:#16a34a; }
+    .practice-dashboard__history-dot--ok-strong{ background:#16a34a; }
+    .practice-dashboard__history-dot--ok-soft{ background:#4ade80; }
     .practice-dashboard__history-dot--mid{ background:#eab308; }
-    .practice-dashboard__history-dot--ko{ background:#dc2626; }
+    .practice-dashboard__history-dot--ko-soft{ background:#f87171; }
+    .practice-dashboard__history-dot--ko-strong{ background:#dc2626; }
     .practice-dashboard__history-dot--na{ background:#94a3b8; }
     .practice-dashboard__empty{ padding:1rem; border-radius:.9rem; border:1px dashed rgba(148,163,184,0.5); background:#f8fafc; font-size:.9rem; color:#64748b; text-align:center; }
     .practice-dashboard__footer{ padding:1rem clamp(1.4rem,4vw,2rem); border-top:1px solid rgba(148,163,184,0.2); background:#fff; display:flex; justify-content:flex-end; }

--- a/modes.js
+++ b/modes.js
@@ -898,9 +898,11 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
         return;
       }
       const statusLabels = {
-        ok: "Positive",
+        "ok-strong": "Très positif",
+        "ok-soft": "Plutôt positif",
         mid: "Intermédiaire",
-        ko: "À surveiller",
+        "ko-soft": "Plutôt négatif",
+        "ko-strong": "Très négatif",
         na: "Sans donnée",
       };
       const cards = stats
@@ -2097,27 +2099,47 @@ function dotColor(type, v){
     return "na";
   }
   if (type === "likert6") {
-    const map = { yes:"ok", rather_yes:"ok", medium:"mid", rather_no:"ko", no:"ko", no_answer:"na" };
+    const map = {
+      yes: "ok-strong",
+      rather_yes: "ok-soft",
+      medium: "mid",
+      rather_no: "ko-soft",
+      no: "ko-strong",
+      no_answer: "na",
+    };
     return map[v] || "na";
   }
   if (type === "likert5") {
     const n = Number(v);
-    return n >= 3 ? "ok" : n === 2 ? "mid" : "ko";
+    if (!Number.isFinite(n)) return "na";
+    if (n >= 5) return "ok-strong";
+    if (n === 4) return "ok-soft";
+    if (n === 3) return "mid";
+    if (n === 2) return "ko-soft";
+    if (n <= 1) return "ko-strong";
+    return "na";
   }
   if (type === "yesno") {
-    return v === "yes" ? "ok" : "ko";
+    if (v === "yes") return "ok-strong";
+    if (v === "no") return "ko-strong";
+    return "na";
   }
   if (type === "num") {
-    const n = Number(v) || 0;
-    return n >= 7 ? "ok" : n >= 4 ? "mid" : "ko";
+    const n = Number(v);
+    if (!Number.isFinite(n)) return "na";
+    if (n >= 7) return "ok-strong";
+    if (n >= 4) return "mid";
+    return "ko-strong";
   }
   return "na";
 }
 
 const STATUS_LABELS = {
-  ok: "Positive",
+  "ok-strong": "Très positif",
+  "ok-soft": "Plutôt positif",
   mid: "Intermédiaire",
-  ko: "À surveiller",
+  "ko-soft": "Plutôt négatif",
+  "ko-strong": "Très négatif",
   na: "Sans donnée",
 };
 


### PR DESCRIPTION
## Summary
- map Likert and related inputs to distinct status codes and expose new labels in the UI
- restyle consigne rows and practice history dots with pastel colors for each status level

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e125f89618833386303c39322b7175