### PR TITLE
Réduire l'espacement des consignes

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
         padding-inline:0;
       }
       .consigne-row {
-        padding:.55rem 0;
+        padding:.35rem 0;
       }
       .consigne-row--child {
         margin-left:.5rem;
@@ -466,7 +466,7 @@
         padding:.2rem .5rem .55rem;
       }
       .consigne-row {
-        padding:.5rem 0;
+        padding:.3rem 0;
       }
       .tab {
         padding:.4rem .65rem;
@@ -492,7 +492,7 @@
     }
     .daily-category__items {
       display:grid;
-      gap:.4rem;
+      gap:.2rem;
       flex:1 1 auto;
     }
     .daily-category__low {
@@ -534,8 +534,8 @@
       position:relative;
       display:flex;
       flex-direction:column;
-      gap:.65rem;
-      padding:.6rem 0;
+      gap:.4rem;
+      padding:.4rem 0;
       --consigne-status-bg:transparent;
       --consigne-status-border:rgba(148,163,184,.18);
       --consigne-status-text:#0f172a;
@@ -566,12 +566,12 @@
       display:flex;
       align-items:flex-start;
       justify-content:space-between;
-      gap:.85rem;
+      gap:.5rem;
     }
     .consigne-row__main {
       display:flex;
       align-items:center;
-      gap:.55rem;
+      gap:.35rem;
       flex:1 1 auto;
       min-width:0;
     }
@@ -816,7 +816,7 @@
 
     .consigne-group {
       display:grid;
-      gap:.35rem;
+      gap:.2rem;
     }
     .consigne-group__children {
       margin-top:-.2rem;


### PR DESCRIPTION
## Summary
- réduit le padding vertical et les espacements internes des consignes pour compacter chaque ligne
- ajuste les gaps des en-têtes et les espacements de groupe afin de supprimer les blancs superflus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1384cd6c8833394317bfa70e0a515