### PR TITLE
Ajuster les espacements des consignes quotidiennes

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,11 +442,11 @@
         padding-inline:0;
       }
       .consigne-row {
-        padding:.35rem 0;
+        padding:.26rem 0;
       }
       .consigne-row--child {
-        margin-left:.5rem;
-        padding-left:1rem;
+        margin-left:.4rem;
+        padding-left:.75rem;
         border-left:2px solid rgba(148,163,184,.2);
       }
       .consigne-actions__panel {
@@ -463,10 +463,10 @@
         padding:.9rem .6rem 1rem;
       }
       .consigne-group__children {
-        padding:.2rem .5rem .55rem;
+        padding:.15rem .4rem .45rem;
       }
       .consigne-row {
-        padding:.3rem 0;
+        padding:.22rem 0;
       }
       .tab {
         padding:.4rem .65rem;
@@ -492,7 +492,7 @@
     }
     .daily-category__items {
       display:grid;
-      gap:.2rem;
+      gap:.14rem;
       flex:1 1 auto;
     }
     .daily-category__low {
@@ -517,7 +517,7 @@
     .daily-category__items--nested {
       margin-top:.45rem;
       display:grid;
-      gap:.4rem;
+      gap:.16rem;
     }
     ul.consigne-list {
       list-style:none;
@@ -534,8 +534,8 @@
       position:relative;
       display:flex;
       flex-direction:column;
-      gap:.4rem;
-      padding:.4rem 0;
+      gap:.24rem;
+      padding:.32rem 0;
       --consigne-status-bg:transparent;
       --consigne-status-border:rgba(148,163,184,.18);
       --consigne-status-text:#0f172a;
@@ -566,12 +566,12 @@
       display:flex;
       align-items:flex-start;
       justify-content:space-between;
-      gap:.5rem;
+      gap:.35rem;
     }
     .consigne-row__main {
       display:flex;
       align-items:center;
-      gap:.35rem;
+      gap:.24rem;
       flex:1 1 auto;
       min-width:0;
     }
@@ -754,15 +754,15 @@
       margin-top:0;
     }
     .consigne-row--child {
-      margin-left:1.25rem;
-      padding-left:1.25rem;
+      margin-left:.6rem;
+      padding-left:.9rem;
       border-left:2px solid rgba(148,163,184,.2);
     }
     .consigne-row--child:first-child {
       border-top:none;
     }
     .consigne-row--child .consigne-row__header {
-      gap:.65rem;
+      gap:.42rem;
     }
     .daily-consigne__actions {
       position:relative;
@@ -835,7 +835,7 @@
     }
     .consigne-group__children {
       margin-top:-.2rem;
-      padding:.25rem .75rem .7rem;
+      padding:.18rem .6rem .52rem;
       border-radius:.85rem;
       background:rgba(148,163,184,.08);
       width:100%;
@@ -865,8 +865,8 @@
     }
     .consigne-group__list {
       display:grid;
-      gap:.5rem;
-      margin-top:.35rem;
+      gap:.28rem;
+      margin-top:.28rem;
     }
     .consigne-card--child {
       margin-left:1rem;


### PR DESCRIPTION
## Summary
- resserre les espacements verticaux des lignes de consignes et de leurs sous-éléments
- réduit les marges d’indentation des consignes enfants pour garder la hiérarchie tout en gagnant de la place
- harmonise les espacements des conteneurs de catégories quotidiennes pour une liste plus compacte

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e13d2004f88333975dd8c4f5e9f8c5