### PR TITLE
Adjust consigne status colors for clearer contrasts

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,22 +657,22 @@
     .consigne-row[data-status="ok-strong"],
     .consigne-row__status[data-status="ok-strong"],
     .consigne-status--ok-strong {
-      --consigne-status-bg:#dcfce7;
-      --consigne-status-border:rgba(34,197,94,.28);
-      --consigne-status-text:#14532d;
-      --consigne-status-accent:#166534;
-      --consigne-status-color:#16a34a;
-      --consigne-status-dot-shadow:rgba(34,197,94,.25);
+      --consigne-status-bg:#bff2c8;
+      --consigne-status-border:rgba(4,120,87,.35);
+      --consigne-status-text:#064e3b;
+      --consigne-status-accent:#047857;
+      --consigne-status-color:#0f9d58;
+      --consigne-status-dot-shadow:rgba(4,120,87,.26);
     }
     .consigne-row[data-status="ok-soft"],
     .consigne-row__status[data-status="ok-soft"],
     .consigne-status--ok-soft {
-      --consigne-status-bg:#f0fdf4;
-      --consigne-status-border:rgba(74,222,128,.24);
+      --consigne-status-bg:#eafbf0;
+      --consigne-status-border:rgba(52,211,153,.24);
       --consigne-status-text:#166534;
       --consigne-status-accent:#15803d;
-      --consigne-status-color:#4ade80;
-      --consigne-status-dot-shadow:rgba(74,222,128,.22);
+      --consigne-status-color:#34d399;
+      --consigne-status-dot-shadow:rgba(52,211,153,.2);
     }
     .consigne-row[data-status="mid"],
     .consigne-row__status[data-status="mid"],
@@ -687,22 +687,22 @@
     .consigne-row[data-status="ko-soft"],
     .consigne-row__status[data-status="ko-soft"],
     .consigne-status--ko-soft {
-      --consigne-status-bg:#fef2f2;
-      --consigne-status-border:rgba(248,113,113,.28);
+      --consigne-status-bg:#fcebed;
+      --consigne-status-border:rgba(248,113,113,.22);
       --consigne-status-text:#7f1d1d;
-      --consigne-status-accent:#b91c1c;
-      --consigne-status-color:#f87171;
-      --consigne-status-dot-shadow:rgba(248,113,113,.24);
+      --consigne-status-accent:#c53030;
+      --consigne-status-color:#fb7185;
+      --consigne-status-dot-shadow:rgba(248,113,113,.2);
     }
     .consigne-row[data-status="ko-strong"],
     .consigne-row__status[data-status="ko-strong"],
     .consigne-status--ko-strong {
-      --consigne-status-bg:#fee2e2;
-      --consigne-status-border:rgba(220,38,38,.32);
-      --consigne-status-text:#7f1d1d;
+      --consigne-status-bg:#f8d4d4;
+      --consigne-status-border:rgba(185,28,28,.32);
+      --consigne-status-text:#651414;
       --consigne-status-accent:#991b1b;
-      --consigne-status-color:#dc2626;
-      --consigne-status-dot-shadow:rgba(220,38,38,.26);
+      --consigne-status-color:#c81e1e;
+      --consigne-status-dot-shadow:rgba(185,28,28,.26);
     }
     .consigne-row[data-status="na"],
     .consigne-row__status[data-status="na"],
@@ -715,24 +715,24 @@
       --consigne-status-dot-shadow:rgba(148,163,184,.2);
     }
     .consigne-row__dot--ok-strong {
-      background:#16a34a;
-      box-shadow:0 0 0 3px rgba(34,197,94,.25);
+      background:#0f9d58;
+      box-shadow:0 0 0 3px rgba(4,120,87,.26);
     }
     .consigne-row__dot--ok-soft {
-      background:#4ade80;
-      box-shadow:0 0 0 3px rgba(74,222,128,.22);
+      background:#34d399;
+      box-shadow:0 0 0 3px rgba(52,211,153,.2);
     }
     .consigne-row__dot--mid {
       background:#eab308;
       box-shadow:0 0 0 3px rgba(234,179,8,.24);
     }
     .consigne-row__dot--ko-soft {
-      background:#f87171;
-      box-shadow:0 0 0 3px rgba(248,113,113,.24);
+      background:#fb7185;
+      box-shadow:0 0 0 3px rgba(248,113,113,.2);
     }
     .consigne-row__dot--ko-strong {
-      background:#dc2626;
-      box-shadow:0 0 0 3px rgba(220,38,38,.26);
+      background:#c81e1e;
+      box-shadow:0 0 0 3px rgba(185,28,28,.26);
     }
     .consigne-row__dot--na {
       background:#94a3b8;


### PR DESCRIPTION
## Summary
- update status theme variables to create more distinct pastel greens and reds across strong and soft states
- align dot indicators with the refreshed palette for consistent accents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e13ccc79988333a8ae511abb80295f