### PR TITLE
Use modal variant for consigne editor overlays

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -2764,7 +2764,7 @@ async function renderPractice(ctx, root, _opts = {}) {
           },
         },
       }));
-      attachConsigneEditor(row, c, { variant: "drawer" });
+      attachConsigneEditor(row, c, { variant: "modal" });
       bindConsigneRowValue(row, c, {
         onChange: (value) => {
           if (value === null || value === undefined) {
@@ -3179,7 +3179,7 @@ async function renderDaily(ctx, root, opts = {}) {
       },
     }));
 
-    attachConsigneEditor(row, item, { variant: "drawer" });
+    attachConsigneEditor(row, item, { variant: "modal" });
     bindConsigneRowValue(row, item, {
       initialValue,
       onChange: (value) => {


### PR DESCRIPTION
## Summary
- update the practice and daily consigne editors to rely on the modal variant when opening

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e144b1d7e4833385cf12e51d14d023