### PR TITLE
Add visual feedback for consigne status updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,23 @@
     ul.consigne-list > li {
       margin:0;
     }
+    @keyframes consigne-row-updated-pulse {
+      0% {
+        background:rgba(62, 166, 235, .18);
+        box-shadow:0 0 0 0 rgba(62, 166, 235, .45);
+      }
+      60% {
+        background:rgba(62, 166, 235, .08);
+        box-shadow:0 0 0 12px rgba(62, 166, 235, 0);
+      }
+      100% {
+        background:transparent;
+        box-shadow:0 0 0 0 rgba(62, 166, 235, 0);
+      }
+    }
+    .consigne-row--updated {
+      animation:consigne-row-updated-pulse .9s ease-out;
+    }
     .consigne-row {
       position:relative;
       display:flex;


### PR DESCRIPTION
## Summary
- add helper utilities to temporarily apply an update highlight class to consigne rows when answers are saved
- ensure the highlight is skipped for `na` statuses and reset when no data is present
- define CSS keyframes and animation for the update highlight effect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14745a17483339da3e190d0c68484