### PR TITLE
Improve modal viewport handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,12 @@
       --text:    #334155; /* slate-700 */
       --muted:   #94A3B8; /* slate-400 */
       --ring:    var(--accent-400);
+      --viewport-safe-height: calc(100vh - 2rem);
+    }
+    @supports (height: 100dvh) {
+      :root {
+        --viewport-safe-height: calc(100dvh - 2rem);
+      }
     }
     /* Pratique = vert doux */
     [data-section="practice"]{


### PR DESCRIPTION
## Summary
- adjust modal rendering to follow visualViewport changes and cap the dialog height with safe margins
- ensure event listeners are cleaned up when the modal closes and update a fallback CSS variable
- define a CSS fallback variable for browsers without visualViewport support

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e14d414a2c8333b7d066220fadee0e