### PR TITLE
Limit textarea auto-grow height

### DIFF
--- a/goals.js
+++ b/goals.js
@@ -674,6 +674,12 @@
     `;
     document.body.appendChild(wrap);
 
+    wrap.querySelectorAll("textarea").forEach((textarea) => {
+      if (typeof window.autoGrowTextarea === "function") {
+        window.autoGrowTextarea(textarea);
+      }
+    });
+
     const close = () => wrap.remove();
     wrap.addEventListener("click", (event) => {
       if (event.target === wrap) close();

--- a/modes.js
+++ b/modes.js
@@ -8,12 +8,26 @@ const modesLogger = Schema.D || { info: () => {}, group: () => {}, groupEnd: () 
 const $ = (sel, root = document) => root.querySelector(sel);
 const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
 
+// Default limits for auto-growing textareas. The max height can be overridden
+// with a `data-auto-grow-max` attribute when needed, but defaults to 320px to
+// avoid runaway layouts while keeping enough room for comfortable editing.
+const AUTO_GROW_MIN_HEIGHT = 120;
+const AUTO_GROW_DEFAULT_MAX_HEIGHT = 320;
+
 function autoGrowTextarea(el) {
   if (!(el instanceof HTMLTextAreaElement)) return;
   if (el.dataset.autoGrowBound === "true") return;
+  const rawMax = Number.parseInt(el.dataset.autoGrowMax || "", 10);
+  const maxHeight = Math.max(
+    AUTO_GROW_MIN_HEIGHT,
+    Number.isFinite(rawMax) && rawMax > 0 ? rawMax : AUTO_GROW_DEFAULT_MAX_HEIGHT,
+  );
   const resize = () => {
     el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
+    const scrollHeight = el.scrollHeight;
+    const clampedHeight = Math.max(AUTO_GROW_MIN_HEIGHT, Math.min(scrollHeight, maxHeight));
+    el.style.height = `${clampedHeight}px`;
+    el.style.overflowY = scrollHeight > maxHeight ? "auto" : "hidden";
   };
   el.addEventListener("input", resize);
   el.addEventListener("change", resize);


### PR DESCRIPTION
## Summary
- add a documented 320px default maximum height to `autoGrowTextarea`, clamp the height, and toggle overflow scrolling once the limit is hit
- keep a reasonable minimum height while allowing overrides through `data-auto-grow-max`
- wire the goal editor textarea to the shared auto-grow helper so all instances respect the new limits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14f162d548333baa702cd34a17d6a