### PR TITLE
Add checklist consigne type with client and schema support

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -177,7 +177,7 @@ const todayKey = (d = new Date()) => dayKeyFromDate(d); // YYYY-MM-DD
 
 const PRIORITIES = ["high","medium","low"];
 const MODES = ["daily","practice"];
-const TYPES = ["short","long","likert6","likert5","yesno","num","info"];
+const TYPES = ["short","long","likert6","likert5","yesno","num","checklist","info"];
 
 const LIKERT = ["no_answer","no","rather_no","medium","rather_yes","yes"];
 const LIKERT_POINTS = {
@@ -257,6 +257,22 @@ function normalizeParentId(value) {
   return trimmed ? String(trimmed) : null;
 }
 
+function normalizeChecklistItems(items) {
+  if (!Array.isArray(items)) return [];
+  const seen = new Set();
+  const result = [];
+  items.forEach((raw) => {
+    if (typeof raw !== "string") return;
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(trimmed);
+  });
+  return result;
+}
+
 function hydrateConsigne(doc) {
   const data = doc.data();
   return {
@@ -266,6 +282,7 @@ function hydrateConsigne(doc) {
     days: normalizeDays(data.days),
     srEnabled: data.srEnabled !== false,
     parentId: normalizeParentId(data.parentId),
+    checklistItems: normalizeChecklistItems(data.checklistItems),
   };
 }
 
@@ -575,6 +592,7 @@ async function addConsigne(db, uid, payload) {
     priority: normalizePriority(payload.priority),
     days: normalizeDays(payload.days),
     parentId: normalizeParentId(payload.parentId),
+    checklistItems: normalizeChecklistItems(payload.checklistItems),
     createdAt: serverTimestamp()
   });
   return ref;
@@ -588,6 +606,7 @@ async function updateConsigne(db, uid, id, payload) {
     priority: normalizePriority(payload.priority),
     days: normalizeDays(payload.days),
     parentId: normalizeParentId(payload.parentId),
+    checklistItems: normalizeChecklistItems(payload.checklistItems),
     updatedAt: serverTimestamp()
   });
 }
@@ -680,6 +699,16 @@ function valueToNumericPoint(type, value) {
   if (type === "likert5") return Number(value) || 0;  // 0..4
   if (type === "yesno")   return value === "yes" ? 1 : 0;
   if (type === "num") return Number(value) || 0;
+  if (type === "checklist") {
+    const values = Array.isArray(value)
+      ? value
+      : value && typeof value === "object" && Array.isArray(value.items)
+        ? value.items
+        : [];
+    if (!values.length) return null;
+    const completed = values.filter(Boolean).length;
+    return values.length ? completed / values.length : null;
+  }
   return null; // pour short/long -> pas de graph
 }
 


### PR DESCRIPTION
## Summary
- add a checklist response type to the consigne editor with inline item management UI
- render checklist consignes with checkbox inputs, tracking state changes, formatting values, and status colors
- persist checklist item definitions and aggregate checklist answers through the schema helpers for history/exports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24375ba90833392184002aca2b4f0