### PR TITLE
Handle pristine checklists as unanswered

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -3120,6 +3120,9 @@ function dotColor(type, v){
     return "ko-strong";
   }
   if (type === "checklist") {
+    if (v == null) {
+      return "na";
+    }
     const values = Array.isArray(v)
       ? v
       : v && typeof v === "object" && Array.isArray(v.items)
@@ -3287,6 +3290,10 @@ function readConsigneCurrentValue(consigne, scope) {
   if (type === "checklist") {
     const hidden = scope.querySelector(`[name="checklist:${id}"]`);
     if (hidden) {
+      const isDirty = hidden.dataset && hidden.dataset.dirty === "1";
+      if (!isDirty) {
+        return null;
+      }
       try {
         const parsed = JSON.parse(hidden.value || "[]");
         if (Array.isArray(parsed)) {
@@ -4926,3 +4933,10 @@ Modes.renderPractice = renderPractice;
 Modes.renderDaily = renderDaily;
 Modes.renderHistory = renderHistory;
 Modes.attachConsignesDragDrop = window.attachConsignesDragDrop;
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    readConsigneCurrentValue,
+    dotColor,
+  };
+}

--- a/tests/checklistStatus.test.js
+++ b/tests/checklistStatus.test.js
@@ -1,0 +1,118 @@
+const assert = require("assert");
+
+function setupDomStubs() {
+  const noop = () => {};
+  global.window = {
+    Modes: {},
+    firestoreAPI: {},
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: (cb) => {
+      if (typeof cb === "function") {
+        cb();
+      }
+      return 0;
+    },
+    cancelAnimationFrame: noop,
+    __appBadge: null,
+  };
+  global.Modes = global.window.Modes;
+  global.Schema = {
+    firestore: {},
+    DAY_ALIAS: {},
+    DAY_VALUES: new Set(),
+    D: {},
+  };
+  const createElement = (tag = "") => ({
+    tagName: String(tag).toUpperCase(),
+    innerHTML: "",
+    content: {
+      innerHTML: "",
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    appendChild: noop,
+    removeChild: noop,
+    insertBefore: noop,
+    setAttribute: noop,
+    removeAttribute: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    append: noop,
+    remove: noop,
+    replaceWith: noop,
+    classList: { add: noop, remove: noop },
+    style: {},
+    dataset: {},
+    firstChild: null,
+    lastChild: null,
+  });
+  global.document = {
+    createElement,
+    createTreeWalker: () => ({
+      currentNode: null,
+      nextNode: () => false,
+    }),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    body: { appendChild: noop },
+  };
+  global.window.document = global.document;
+  global.Node = { TEXT_NODE: 3 };
+  global.NodeFilter = { SHOW_ELEMENT: 1 };
+  global.Element = function Element() {};
+  global.HTMLTextAreaElement = function HTMLTextAreaElement() {};
+  global.Event = function Event() {};
+  global.performance = { now: () => 0 };
+}
+
+setupDomStubs();
+
+const { readConsigneCurrentValue, dotColor } = require("../modes.js");
+
+function testChecklistValueRemainsNullUntilDirty() {
+  const consigne = { id: "c1", type: "checklist" };
+  const hidden = {
+    value: JSON.stringify([false, false]),
+    dataset: {},
+  };
+  const scope = {
+    querySelector: (selector) => {
+      if (selector === '[name="checklist:c1"]') {
+        return hidden;
+      }
+      return null;
+    },
+  };
+  const initial = readConsigneCurrentValue(consigne, scope);
+  assert.strictEqual(initial, null, "Une checklist neuve doit retourner null tant qu’elle est propre");
+
+  hidden.dataset.dirty = "1";
+  hidden.value = JSON.stringify([true, false]);
+  const afterDirty = readConsigneCurrentValue(consigne, scope);
+  assert.deepStrictEqual(afterDirty, [true, false], "Une checklist marquée sale doit retourner les cases cochées");
+}
+
+function testDotColorTreatsNullAsNa() {
+  assert.strictEqual(dotColor("checklist", null), "na", "La couleur d’un état neutre doit rester grise");
+}
+
+function testDotColorSignalsAllUncheckedAsKo() {
+  assert.strictEqual(
+    dotColor("checklist", [false, false, false]),
+    "ko-strong",
+    "Une checklist explicitement décochée doit s’afficher en rouge",
+  );
+}
+
+try {
+  testChecklistValueRemainsNullUntilDirty();
+  testDotColorTreatsNullAsNa();
+  testDotColorSignalsAllUncheckedAsKo();
+  console.log("All checklist status tests passed.");
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- return `null` from `readConsigneCurrentValue` when checklist inputs are still pristine
- keep checklist status dots neutral until the hidden field is marked dirty
- add a focused checklist status test with DOM stubs

## Testing
- `node tests/checklistStatus.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e2539f4cac8333a5cc5be4c3c7aa86