### PR TITLE
Ensure sub-consigne checklist editor toggles Tailwind hidden state

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -2819,7 +2819,17 @@ async function openConsigneForm(ctx, consigne = null, options = {}) {
       const subChecklistEditor = document.createElement('fieldset');
       subChecklistEditor.className = 'grid gap-2';
       subChecklistEditor.dataset.subChecklistEditor = '';
-      subChecklistEditor.hidden = true;
+      const setSubChecklistVisibility = (visible) => {
+        const isVisible = Boolean(visible);
+        subChecklistEditor.hidden = !isVisible;
+        subChecklistEditor.classList.toggle('hidden', !isVisible);
+        if (!isVisible) {
+          subChecklistEditor.style.display = 'none';
+        } else {
+          subChecklistEditor.style.removeProperty('display');
+        }
+      };
+      setSubChecklistVisibility(false);
       const subChecklistLegend = document.createElement('legend');
       subChecklistLegend.className = 'text-sm text-[var(--muted)]';
       subChecklistLegend.textContent = "Éléments de checklist";
@@ -2912,11 +2922,11 @@ async function openConsigneForm(ctx, consigne = null, options = {}) {
           if (subChecklistList) {
             subChecklistList.innerHTML = '';
           }
-          subChecklistEditor.hidden = true;
+          setSubChecklistVisibility(false);
           renderSubChecklistEmptyState();
           return;
         }
-        subChecklistEditor.hidden = false;
+        setSubChecklistVisibility(true);
         ensureSubChecklistHasRow();
         renderSubChecklistEmptyState();
       };


### PR DESCRIPTION
## Summary
- toggle the Tailwind `hidden` utility and inline display style alongside the hidden attribute for the sub-consigne checklist editor
- apply the same visibility handling on initialization and when clearing the checklist contents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2606086748333b035be030247cb34