### PR TITLE
Use sticky practice editor action bar in consigne modal

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -3731,11 +3731,13 @@ function attachConsigneEditor(row, consigne, options = {}) {
         </section>`
       : "";
     const actionsMarkup = requiresValidation
-      ? `<div class="flex justify-end gap-2">
+      ? `<div class="practice-editor__actions">
           <button type="button" class="btn btn-ghost" data-consigne-editor-cancel>Annuler</button>
           <button type="button" class="btn btn-primary" data-consigne-editor-validate>Valider</button>
         </div>`
-      : `<div class="flex justify-end"><button type="button" class="btn" data-consigne-editor-cancel>Fermer</button></div>`;
+      : `<div class="practice-editor__actions">
+          <button type="button" class="btn" data-consigne-editor-cancel>Fermer</button>
+        </div>`;
     const markup = `
       <div class="space-y-4">
         <header class="space-y-1">


### PR DESCRIPTION
## Summary
- wrap consigne editor buttons with the existing sticky practice-editor action bar
- align the informational "Fermer" variant with the same sticky layout

## Testing
- manual visual verification of the modal action bar on desktop and mobile

------
https://chatgpt.com/codex/tasks/task_e_68e266a480088333a32e4a86c7e4ccf3