### PR TITLE
Improve checklist editor checkbox handling

### DIFF
--- a/checklist-editor.js
+++ b/checklist-editor.js
@@ -1,19 +1,51 @@
-/* checklist-editor.js
-   Comportement "liste à puces" pour les cases à cocher dans un contenteditable.
-   - Mobile: gère 'beforeinput' (insertParagraph / deleteContentBackward/Forward)
-   - Desktop: garde un fallback 'keydown'
-   - Compatible lignes en <div>/<p> (Chrome/Safari) OU <br> (certains resets)
+/* checklist-editor.js — v2
+   Cases à cocher dans un contenteditable qui se comportent comme une vraie liste :
+   - Enter sur "☐ + texte"   => nouvelle case à la ligne suivante
+   - Enter sur "☐ + (vide)"  => sortie du "mode case" (ligne normale, sans case)
+   - Backspace/Suppr au bon endroit => supprime la case (ou "retire la puce" au tout début)
+   Gère:
+     * mobile (Android/iOS) via 'beforeinput' (insertParagraph / insertLineBreak / deleteContentBackward/Forward)
+     * desktop via 'keydown'
+     * éditeurs en <div>/<p>/li par ligne OU séparés par <br>
 */
 
 (function () {
-  const isCb = (n) => !!(n && n.nodeType === 1 && n.classList.contains("cb-wrap"));
+  const isCbWrap = (n) => !!(n && n.nodeType === 1 && n.classList.contains('cb-wrap'));
+  const isCheckboxEl = (n) => !!(n && n.nodeType === 1 && n.tagName === 'INPUT' && n.type === 'checkbox');
+  const isMeaninglessText = (n) =>
+    n &&
+    n.nodeType === 3 &&
+    !n.textContent.replace(/\u200B/g, '').trim();
+
+  function firstMeaningful(node) {
+    let c = node ? node.firstChild : null;
+    while (c && (isMeaninglessText(c) || (c.nodeType === 1 && c.tagName === 'BR'))) {
+      c = c.nextSibling;
+    }
+    return c || null;
+  }
+
+  function hasMeaningfulContent(node) {
+    if (!node) return false;
+    if (node.nodeType === 3) {
+      return !!node.textContent.replace(/\u200B/g, '').trim();
+    }
+    if (node.nodeType !== 1) return false;
+    if (isCbWrap(node) || isCheckboxEl(node) || node.tagName === 'BR') return false;
+    let child = node.firstChild;
+    while (child) {
+      if (hasMeaningfulContent(child)) return true;
+      child = child.nextSibling;
+    }
+    return false;
+  }
 
   function makeCb() {
-    const wrap = document.createElement("span");
-    wrap.className = "cb-wrap";
-    wrap.contentEditable = "false";
-    const cb = document.createElement("input");
-    cb.type = "checkbox";
+    const wrap = document.createElement('span');
+    wrap.className = 'cb-wrap';
+    wrap.contentEditable = 'false';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
     cb.tabIndex = -1;
     wrap.appendChild(cb);
     return wrap;
@@ -21,141 +53,124 @@
 
   const sel = () => (window.getSelection()?.rangeCount ? window.getSelection() : null);
 
-  const firstNonEmpty = (node) => {
-    let c = node.firstChild;
-    while (
-      c &&
-      ((c.nodeType === 3 && !c.textContent.trim()) || (c.nodeType === 1 && c.tagName === "BR"))
-    ) {
-      c = c.nextSibling;
+  function setCaret(rangeOrNode, placeAfter = true) {
+    const s = sel();
+    if (!s) return;
+    let range = null;
+    if (rangeOrNode instanceof Range) {
+      range = rangeOrNode;
+    } else {
+      range = document.createRange();
+      if (placeAfter) range.setStartAfter(rangeOrNode);
+      else range.setStartBefore(rangeOrNode);
+      range.collapse(true);
     }
-    return c;
-  };
+    s.removeAllRanges();
+    s.addRange(range);
+  }
 
   function getLineCtx(editor) {
     const s = sel();
     if (!s) return null;
     const r = s.getRangeAt(0);
-    // remonter jusqu’à un enfant direct de l’éditeur
     let node = r.startContainer;
     while (node && node.parentNode !== editor) node = node.parentNode;
     if (!node) return null;
 
-    // Mode "block" si enfant direct est DIV/P/LI
     if (
       node.nodeType === 1 &&
       node.parentNode === editor &&
       /^(DIV|P|LI)$/i.test(node.tagName)
     ) {
       const block = node;
-      // caret au tout début du block ?
-      const atStart = (() => {
+      const first = firstMeaningful(block);
+      const caretAtStart = (() => {
         if (!r.collapsed) return false;
         if (r.startContainer.nodeType === 3 && r.startOffset > 0) return false;
         let cur = r.startContainer;
         while (cur && cur.parentNode !== block) cur = cur.parentNode;
-        return cur === firstNonEmpty(block) || cur === block;
+        return cur === first || cur === block;
       })();
-      return { mode: "block", block, first: firstNonEmpty(block), caretAtStart: atStart };
+      return { mode: 'block', block, first, caretAtStart };
     }
 
-    // Sinon, mode "inline" (lignes séparées par <br>)
     let prev = node.previousSibling;
-    while (prev && prev.nodeName !== "BR") prev = prev.previousSibling;
+    while (prev && prev.nodeName !== 'BR') prev = prev.previousSibling;
     let first = prev ? prev.nextSibling : editor.firstChild;
-    while (first && first.nodeType === 3 && !first.textContent.trim()) first = first.nextSibling;
+    while (first && isMeaninglessText(first)) first = first.nextSibling;
     const caretAtStart =
       r.collapsed && !(r.startContainer.nodeType === 3 && r.startOffset > 0);
-    return { mode: "inline", node, first, caretAtStart };
+    return { mode: 'inline', node, first, caretAtStart };
   }
 
-  const lineStartsWithCb = (ctx) => !!(ctx && isCb(ctx.first));
+  function startsWithCheckbox(ctx) {
+    if (!ctx || !ctx.first) return false;
+    return isCbWrap(ctx.first) || isCheckboxEl(ctx.first);
+  }
 
-  function lineEmptyAfterCb(editor, ctx) {
-    if (!lineStartsWithCb(ctx)) return false;
-    if (ctx.mode === "block") {
+  function emptyAfterCheckbox(editor, ctx) {
+    if (!startsWithCheckbox(ctx)) return false;
+
+    if (ctx.mode === 'block') {
       let n = ctx.first.nextSibling;
       while (n) {
-        if (
-          (n.nodeType === 3 && n.textContent.trim()) ||
-          (n.nodeType === 1 && !isCb(n) && n.textContent.trim())
-        )
-          return false;
+        if (hasMeaningfulContent(n)) return false;
         n = n.nextSibling;
       }
       return true;
     }
-    // inline
+
     let n = ctx.first.nextSibling;
-    while (n && n !== editor) {
-      if (n.nodeName === "BR") break;
-      if (
-        (n.nodeType === 3 && n.textContent.trim()) ||
-        (n.nodeType === 1 && !isCb(n) && n.textContent.trim())
-      )
-        return false;
+    while (n) {
+      if (n.nodeName === 'BR') break;
+      if (hasMeaningfulContent(n)) return false;
       n = n.nextSibling;
     }
     return true;
   }
 
-  function setCaret(rangeOrNode, startAfter = true) {
+  function removeLeadingCheckbox(ctx) {
+    if (!startsWithCheckbox(ctx)) return null;
+    const checkbox = ctx.first;
+    const parent = checkbox.parentNode;
+    let next = checkbox.nextSibling;
+    checkbox.remove();
+
+    while (next && isMeaninglessText(next)) {
+      const toRemove = next;
+      next = next.nextSibling;
+      toRemove.remove();
+    }
+
+    if (parent && parent.normalize) parent.normalize();
+    return { parent, next };
+  }
+
+  function insertLineWithCheckbox(editor, ctx) {
+    if (ctx.mode === 'block') {
+      const newBlock = document.createElement(ctx.block.tagName);
+      const wrap = makeCb();
+      newBlock.appendChild(wrap);
+      newBlock.appendChild(document.createTextNode(' '));
+      ctx.block.after(newBlock);
+      const range = document.createRange();
+      range.setStart(newBlock, newBlock.childNodes.length);
+      range.collapse(true);
+      setCaret(range);
+      return;
+    }
+
     const s = sel();
     if (!s) return;
-    let r = null;
-    if (rangeOrNode instanceof Range) r = rangeOrNode;
-    else {
-      r = document.createRange();
-      if (startAfter) r.setStartAfter(rangeOrNode);
-      else r.setStartBefore(rangeOrNode);
-      r.collapse(true);
-    }
-    s.removeAllRanges();
-    s.addRange(r);
-  }
-
-  function insertPlainLine(editor, ctx) {
-    if (ctx.mode === "block") {
-      const newBlock = document.createElement(ctx.block.tagName);
-      newBlock.appendChild(document.createElement("br")); // vrai bloc vide
-      ctx.block.after(newBlock);
-      const r = document.createRange();
-      r.setStart(newBlock, 0);
-      r.collapse(true);
-      setCaret(r);
-      return;
-    }
-    const s = sel();
-    const r = s.getRangeAt(0);
-    const br = document.createElement("br");
-    r.deleteContents();
-    r.insertNode(br);
-    setCaret(br);
-  }
-
-  function insertLineWithCb(editor, ctx) {
-    if (ctx.mode === "block") {
-      const nb = document.createElement(ctx.block.tagName);
-      const wrap = makeCb();
-      nb.appendChild(wrap);
-      nb.appendChild(document.createTextNode(" "));
-      ctx.block.after(nb);
-      const r = document.createRange();
-      r.setStart(nb, nb.childNodes.length);
-      r.collapse(true);
-      setCaret(r);
-      return;
-    }
-    const s = sel();
-    const r = s.getRangeAt(0);
-    const br = document.createElement("br");
-    r.deleteContents();
-    r.insertNode(br);
-    r.setStartAfter(br);
-    r.collapse(true);
+    const range = s.getRangeAt(0);
+    const br = document.createElement('br');
+    range.deleteContents();
+    range.insertNode(br);
+    range.setStartAfter(br);
+    range.collapse(true);
     const wrap = makeCb();
-    r.insertNode(wrap);
-    const space = document.createTextNode(" ");
+    range.insertNode(wrap);
+    const space = document.createTextNode(' ');
     const r2 = document.createRange();
     r2.setStartAfter(wrap);
     r2.collapse(true);
@@ -165,207 +180,211 @@
     setCaret(r2);
   }
 
-  function removeLeadingCb(editor, ctx) {
-    const first = ctx.first;
-    if (!isCb(first)) return false;
-    const space = first.nextSibling;
-    if (space && space.nodeType === 3 && /^\s$/.test(space.textContent)) space.remove();
-    first.remove();
+  function insertPlainLine(editor, ctx) {
+    const removal = removeLeadingCheckbox(ctx);
+    if (!removal) return false;
+
+    if (ctx.mode === 'block') {
+      const block = ctx.block;
+      if (!block.textContent.replace(/\u200B/g, '').trim()) {
+        block.innerHTML = '';
+        block.appendChild(document.createElement('br'));
+      }
+      const range = document.createRange();
+      range.setStart(block, 0);
+      range.collapse(true);
+      setCaret(range);
+    } else {
+      const range = document.createRange();
+      if (removal.next && removal.next.nodeName === 'BR') {
+        range.setStartAfter(removal.next);
+      } else if (removal.next) {
+        range.setStartBefore(removal.next);
+      } else if (removal.parent) {
+        range.selectNodeContents(removal.parent);
+        range.collapse(false);
+      } else {
+        range.selectNodeContents(editor);
+        range.collapse(false);
+      }
+      const br = document.createElement('br');
+      range.insertNode(br);
+      setCaret(br);
+    }
     return true;
   }
 
-  function deleteAdjacentCb(editor, ctx, direction /*'back'|'del'*/) {
+  function deleteAdjacentCheckbox(editor, ctx, direction /* 'back' | 'del' */) {
     const s = sel();
     if (!s) return false;
-    const r = s.getRangeAt(0);
-    if (!r.collapsed) return false;
+    const range = s.getRangeAt(0);
+    if (!range.collapsed) return false;
 
-    // 1) tout début de ligne checkbox → retirer la "puce"
-    if (ctx.caretAtStart && lineStartsWithCb(ctx) && direction === "back") {
-      return removeLeadingCb(editor, ctx);
+    if (direction === 'back' && ctx.caretAtStart && startsWithCheckbox(ctx)) {
+      const removal = removeLeadingCheckbox(ctx);
+      if (!removal) return false;
+      if (ctx.mode === 'block') {
+        const block = ctx.block;
+        if (!block.textContent.replace(/\u200B/g, '').trim()) {
+          block.innerHTML = '';
+          block.appendChild(document.createElement('br'));
+        }
+        const caretRange = document.createRange();
+        caretRange.setStart(block, 0);
+        caretRange.collapse(true);
+        setCaret(caretRange);
+      } else {
+        const caretRange = document.createRange();
+        if (removal.next) {
+          caretRange.setStartBefore(removal.next);
+        } else if (removal.parent) {
+          caretRange.selectNodeContents(removal.parent);
+          caretRange.collapse(false);
+        } else {
+          caretRange.selectNodeContents(editor);
+          caretRange.collapse(false);
+        }
+        setCaret(caretRange);
+      }
+      return true;
     }
 
-    // 2) sinon, supprimer la cb voisine
-    if (ctx.mode === "block") {
-      let n = r.startContainer;
-      while (n && n.parentNode !== ctx.block) n = n.parentNode;
-      const container = n || ctx.block;
-
-      if (direction === "back") {
-        if (r.startContainer.nodeType === 3 && r.startOffset > 0) return false;
-        let t = container.previousSibling;
-        if (t && t.nodeType === 3 && /^\s$/.test(t.textContent)) {
-          const x = t.previousSibling;
-          if (isCb(x)) {
-            t.remove();
-            t = x;
-          }
+    const checkNeighbor = (candidate) => {
+      if (!candidate) return false;
+      if (candidate.nodeType === 3 && !candidate.textContent.replace(/\u200B/g, '').trim()) {
+        const nextCandidate = direction === 'back' ? candidate.previousSibling : candidate.nextSibling;
+        if (nextCandidate && (isCbWrap(nextCandidate) || isCheckboxEl(nextCandidate))) {
+          candidate.remove();
+          return removeNode(nextCandidate);
         }
-        if (isCb(t)) {
-          const nb = t.previousSibling;
-          if (nb && nb.nodeType === 3 && /^\s$/.test(nb.textContent)) nb.remove();
-          t.remove();
-          return true;
-        }
-      } else {
-        if (
-          r.startContainer.nodeType === 3 &&
-          r.startOffset < r.startContainer.textContent.length
-        )
-          return false;
-        let t = container.nextSibling;
-        if (t && t.nodeType === 3 && /^\s$/.test(t.textContent)) {
-          const x = t.nextSibling;
-          if (isCb(x)) {
-            t.remove();
-            t = x;
-          }
-        }
-        if (isCb(t)) {
-          const nb = t.nextSibling;
-          if (nb && nb.nodeType === 3 && /^\s$/.test(nb.textContent)) nb.remove();
-          t.remove();
-          return true;
-        }
+      }
+      if (isCbWrap(candidate) || isCheckboxEl(candidate)) {
+        return removeNode(candidate);
       }
       return false;
+    };
+
+    function removeNode(node) {
+      const sibling = direction === 'back' ? node.previousSibling : node.nextSibling;
+      node.remove();
+      if (sibling && sibling.nodeType === 3 && !sibling.textContent.replace(/\u200B/g, '').trim()) {
+        sibling.remove();
+      }
+      return true;
     }
 
-    // inline
-    let node = r.startContainer;
-    while (node && node.parentNode !== editor) node = node.parentNode;
-    if (!node) return false;
-
-    if (direction === "back") {
-      if (r.startContainer.nodeType === 3 && r.startOffset > 0) return false;
-      let t = node.previousSibling;
-      if (t && t.nodeType === 3 && /^\s$/.test(t.textContent)) {
-        const x = t.previousSibling;
-        if (isCb(x)) {
-          t.remove();
-          t = x;
-        }
+    if (ctx.mode === 'block') {
+      let container = range.startContainer;
+      while (container && container.parentNode !== ctx.block) container = container.parentNode;
+      if (!container) container = ctx.block;
+      if (direction === 'back') {
+        if (range.startContainer.nodeType === 3 && range.startOffset > 0) return false;
+        return checkNeighbor(container.previousSibling);
       }
-      if (isCb(t)) {
-        const nb = t.previousSibling;
-        if (nb && nb.nodeType === 3 && /^\s$/.test(nb.textContent)) nb.remove();
-        t.remove();
-        return true;
-      }
-    } else {
       if (
-        r.startContainer.nodeType === 3 &&
-        r.startOffset < r.startContainer.textContent.length
+        range.startContainer.nodeType === 3 &&
+        range.startOffset < range.startContainer.textContent.length
       )
         return false;
-      let t = node.nextSibling;
-      if (t && t.nodeType === 3 && /^\s$/.test(t.textContent)) {
-        const x = t.nextSibling;
-        if (isCb(x)) {
-          t.remove();
-          t = x;
-        }
-      }
-      if (isCb(t)) {
-        const nb = t.nextSibling;
-        if (nb && nb.nodeType === 3 && /^\s$/.test(nb.textContent)) nb.remove();
-        t.remove();
-        return true;
-      }
+      return checkNeighbor(container.nextSibling);
     }
-    return false;
+
+    let container = range.startContainer;
+    while (container && container.parentNode !== editor) container = container.parentNode;
+    if (!container) return false;
+    if (direction === 'back') {
+      if (range.startContainer.nodeType === 3 && range.startOffset > 0) return false;
+      return checkNeighbor(container.previousSibling);
+    }
+    if (
+      range.startContainer.nodeType === 3 &&
+      range.startOffset < range.startContainer.textContent.length
+    )
+      return false;
+    return checkNeighbor(container.nextSibling);
   }
 
   function onInsertParagraph(editor) {
     const ctx = getLineCtx(editor);
-    if (!ctx || !lineStartsWithCb(ctx)) return false;
-    if (lineEmptyAfterCb(editor, ctx)) insertPlainLine(editor, ctx); // item vide -> sortir
-    else insertLineWithCb(editor, ctx); // sinon -> nouvel item
+    if (!ctx || !startsWithCheckbox(ctx)) return false;
+    if (emptyAfterCheckbox(editor, ctx)) insertPlainLine(editor, ctx);
+    else insertLineWithCheckbox(editor, ctx);
     return true;
   }
+
   function onDeleteBackward(editor) {
     const ctx = getLineCtx(editor);
     if (!ctx) return false;
-    return deleteAdjacentCb(editor, ctx, "back");
+    return deleteAdjacentCheckbox(editor, ctx, 'back');
   }
+
   function onDeleteForward(editor) {
     const ctx = getLineCtx(editor);
     if (!ctx) return false;
-    return deleteAdjacentCb(editor, ctx, "del");
+    return deleteAdjacentCheckbox(editor, ctx, 'del');
   }
 
   window.setupChecklistEditor = function (editor, insertBtn) {
     if (!editor || editor.__cbInstalled) return;
     editor.__cbInstalled = true;
 
-    // ---- Mobile-first: beforeinput ----
     editor.addEventListener(
-      "beforeinput",
+      'beforeinput',
       (e) => {
-        // IMPORTANT: must be able to preventDefault()
-        if (e.inputType === "insertParagraph") {
-          if (onInsertParagraph(editor)) {
-            e.preventDefault();
-          }
-        } else if (e.inputType === "deleteContentBackward") {
-          if (onDeleteBackward(editor)) {
-            e.preventDefault();
-          }
-        } else if (e.inputType === "deleteContentForward") {
-          if (onDeleteForward(editor)) {
-            e.preventDefault();
-          }
+        if (e.inputType === 'insertParagraph' || e.inputType === 'insertLineBreak') {
+          if (onInsertParagraph(editor)) e.preventDefault();
+        } else if (e.inputType === 'deleteContentBackward') {
+          if (onDeleteBackward(editor)) e.preventDefault();
+        } else if (e.inputType === 'deleteContentForward') {
+          if (onDeleteForward(editor)) e.preventDefault();
         }
       },
       { capture: true },
     );
 
-    // ---- Desktop fallback: keydown ----
-    editor.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") {
+    editor.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
         if (onInsertParagraph(editor)) {
           e.preventDefault();
           return;
         }
       }
-      if (e.key === "Backspace") {
+      if (e.key === 'Backspace') {
         if (onDeleteBackward(editor)) {
           e.preventDefault();
           return;
         }
       }
-      if (e.key === "Delete") {
+      if (e.key === 'Delete') {
         if (onDeleteForward(editor)) {
           e.preventDefault();
-          return;
         }
       }
     });
 
-    // ---- Bouton "☐" ----
     if (insertBtn) {
-      insertBtn.addEventListener("click", () => {
+      insertBtn.addEventListener('click', () => {
         editor.focus();
         const s = sel();
         if (!s) return;
-        const r = s.getRangeAt(0);
+        const range = s.getRangeAt(0);
         const node = makeCb();
-        r.deleteContents();
-        r.insertNode(node);
-        const space = document.createTextNode(" ");
-        const r2 = document.createRange();
-        r2.setStartAfter(node);
-        r2.collapse(true);
-        r2.insertNode(space);
-        r2.setStartAfter(space);
-        r2.setEndAfter(space);
+        range.deleteContents();
+        range.insertNode(node);
+        const space = document.createTextNode(' ');
+        const after = document.createRange();
+        after.setStartAfter(node);
+        after.collapse(true);
+        after.insertNode(space);
+        after.setStartAfter(space);
+        after.setEndAfter(space);
         s.removeAllRanges();
-        s.addRange(r2);
+        s.addRange(after);
       });
     }
   };
 
-  if (typeof window !== "undefined") {
+  if (typeof window !== 'undefined') {
     window.setupCheckboxListBehavior = window.setupChecklistEditor;
   }
 })();


### PR DESCRIPTION
## Summary
- overhaul checklist editor checkbox detection to treat whitespace, checkbox inputs, and block/inline line formats consistently
- adjust beforeinput/keydown handling so Enter on empty items exits the checklist while Backspace/Delete cleanly remove checkboxes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bd79dbdc83338f3436edf25b70dc