### PR TITLE
Normalize checklist checkbox wrappers and guard editor listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -1300,6 +1300,13 @@
       white-space:pre-wrap;
       word-break:break-word;
     }
+    #rt-editor,
+    #rt-editor *,
+    .rt-editor,
+    .rt-editor *{
+      user-select:text !important;
+      pointer-events:auto !important;
+    }
     .consigne-rich-text__content p{ margin:.35rem 0; }
     .editor ul,
     #rt-editor ul,


### PR DESCRIPTION
## Summary
- normalize checkbox inputs across all checklist editors by wrapping stray inputs, enforcing data attributes, and scheduling cleanup when editors focus or change
- tighten key handling so Enter/Backspace/Delete stop propagating once handled and ensure toolbar insert buttons restore the caret inside the editor
- align rich-text editor styling to keep selections interactive by forcing pointer events and user-select on the editable surface

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d7a8effc833381bb25ad8ff722b1