### PR TITLE
Fix Enter behavior for empty checkbox lines

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
 // sw.js — alias conservé pour compatibilité. Le service worker principal est firebase-messaging-sw.js.
-const CACHE_VERSION = "v2024-10-05-2";
+const CACHE_VERSION = "v2024-10-05-3";
 self.__APP_CACHE_VERSION = CACHE_VERSION;
 importScripts("./firebase-messaging-sw.js");


### PR DESCRIPTION
## Summary
- treat non-breaking and zero-width spaces as empty when checking checkbox lines
- prevent native Enter on checkbox lines and remove an empty checkbox inline without inserting extra breaks
- bump the legacy service worker cache version to refresh the updated script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ec084b348333846fb8672cf6ecb1