### PR TITLE
Improve checkbox editor handling and bump service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,21 @@
 // sw.js — alias conservé pour compatibilité. Le service worker principal est firebase-messaging-sw.js.
-const CACHE_VERSION = "v2024-10-05-3";
-self.__APP_CACHE_VERSION = CACHE_VERSION;
+const CACHE_V = "v2025-10-06-01";
+const CACHE_NAME = `app-${CACHE_V}`;
+self.__APP_CACHE_VERSION = CACHE_V;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil((async () => {
+    await self.skipWaiting();
+    await caches.open(CACHE_NAME);
+  })());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)));
+    await self.clients.claim();
+  })());
+});
+
 importScripts("./firebase-messaging-sw.js");


### PR DESCRIPTION
## Summary
- prevent the rich text editor form from intercepting Enter submissions and guard the checkbox setup from running multiple times
- refine the checkbox editor helpers so empty checkbox lines are removed in place, normalization always wraps inputs, and debugging helpers are exposed
- bump the service worker cache version and clear old entries during activation to ensure the latest scripts load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2edc9ed748333886f85fe6f1d89cb