### PR TITLE
Ensure empty checkbox lines stay editable after Enter

### DIFF
--- a/text-editor-checkboxes.js
+++ b/text-editor-checkboxes.js
@@ -232,8 +232,19 @@
     const r = document.createRange();
 
     if (ctx.mode === 'block') {
-      if (!ctx.block.textContent || isReallyEmptyText(ctx.block.textContent)) ctx.block.innerHTML = '<br>';
-      r.setStart(ctx.block, ctx.block.childNodes.length);
+      let caretNode = null;
+      if (!ctx.block.textContent || isReallyEmptyText(ctx.block.textContent)) {
+        while (ctx.block.firstChild) ctx.block.removeChild(ctx.block.firstChild);
+        caretNode = document.createTextNode('');
+        ctx.block.appendChild(caretNode);
+      } else {
+        caretNode = ctx.block.lastChild;
+        if (!caretNode || caretNode.nodeType !== 3) {
+          caretNode = document.createTextNode('');
+          ctx.block.appendChild(caretNode);
+        }
+      }
+      r.setStart(caretNode, caretNode.textContent.length);
     } else {
       let caretNode = null;
       if (anchor && anchor.parentNode === editor) {


### PR DESCRIPTION
## Summary
- adjust removal logic for empty checkbox lines to rebuild the block with a text node
- keep the caret inside the editable block so users can continue typing immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f15fd0c88333b4711b939bfda8bc