### PR TITLE
Fix Enter handling on empty checklist items

### DIFF
--- a/checklist-editor.js
+++ b/checklist-editor.js
@@ -391,6 +391,16 @@
     if (!editor || editor.__cbInstalled) return;
     editor.__cbInstalled = true;
 
+    if (typeof window.installChecklistEnterExit === "function") {
+      try {
+        window.installChecklistEnterExit(editor);
+      } catch (error) {
+        if (window.console && typeof window.console.warn === "function") {
+          console.warn("[checklist-editor] installChecklistEnterExit", error);
+        }
+      }
+    }
+
     normalizeCheckboxes(editor);
 
     let normalizeScheduled = false;
@@ -410,6 +420,7 @@
     editor.addEventListener(
       "beforeinput",
       (e) => {
+        if (e.defaultPrevented) return;
         normalizeCheckboxes(editor);
         if (e.inputType === "insertParagraph" || e.inputType === "insertLineBreak") {
           if (onInsertParagraph(editor)) {
@@ -433,6 +444,7 @@
 
     editor.addEventListener("keydown", (e) => {
       normalizeCheckboxes(editor);
+      if (e.defaultPrevented) return;
       if (e.key === "Enter") {
         if (onInsertParagraph(editor)) {
           e.preventDefault();

--- a/checklist-fix.js
+++ b/checklist-fix.js
@@ -1,0 +1,129 @@
+(function () {
+  function installChecklistEnterExit(rootEl) {
+    if (!rootEl || rootEl.__checklistExitInstalled) return;
+    rootEl.__checklistExitInstalled = true;
+
+    rootEl.addEventListener(
+      "beforeinput",
+      (e) => {
+        if (e.defaultPrevented) return;
+        if (e.inputType === "insertParagraph") {
+          const selection = getSelection();
+          const li = closestTaskItemWithCheckbox(selection?.anchorNode, rootEl);
+          if (!li) return;
+          if (!isTaskItemEmpty(li)) return;
+
+          e.preventDefault();
+          exitEmptyTaskItem(li);
+        } else if (e.inputType === "deleteContentBackward") {
+          const selection = getSelection();
+          if (!selection || !selection.isCollapsed) return;
+          const li = closestTaskItemWithCheckbox(selection.anchorNode, rootEl);
+          if (!li) return;
+          if (!isCaretAtStartOf(li, selection)) return;
+          if (!isTaskItemEmpty(li)) return;
+
+          e.preventDefault();
+          exitEmptyTaskItem(li);
+        }
+      },
+      { capture: true }
+    );
+
+    rootEl.addEventListener("keydown", (e) => {
+      if (e.defaultPrevented || e.isComposing) return;
+      if (e.key === "Enter") {
+        const selection = getSelection();
+        const li = closestTaskItemWithCheckbox(selection?.anchorNode, rootEl);
+        if (!li) return;
+        if (!isTaskItemEmpty(li)) return;
+
+        e.preventDefault();
+        exitEmptyTaskItem(li);
+      } else if (e.key === "Backspace") {
+        const selection = getSelection();
+        if (!selection || !selection.isCollapsed) return;
+        const li = closestTaskItemWithCheckbox(selection.anchorNode, rootEl);
+        if (!li) return;
+        if (!isCaretAtStartOf(li, selection)) return;
+        if (!isTaskItemEmpty(li)) return;
+
+        e.preventDefault();
+        exitEmptyTaskItem(li);
+      }
+    });
+  }
+
+  function closestTaskItemWithCheckbox(node, rootEl) {
+    for (let n = node; n && n !== rootEl; n = n.parentNode) {
+      if (n.nodeType === 1 && n.nodeName === "LI") {
+        if (n.querySelector?.('input[type="checkbox"]')) {
+          return n;
+        }
+      }
+    }
+    return null;
+  }
+
+  function isTaskItemEmpty(li) {
+    if (!li) return false;
+    const clone = li.cloneNode(true);
+    clone.querySelectorAll('input[type="checkbox"], br').forEach((n) => n.remove());
+    const text = clone.textContent.replace(/\u200B/g, "").trim();
+    return text.length === 0;
+  }
+
+  function exitEmptyTaskItem(li) {
+    if (!li) return;
+    const list = li.parentElement;
+    if (!list) return;
+    const doc = li.ownerDocument || document;
+    const onlyItem = list.children.length === 1;
+
+    const paragraph = doc.createElement("p");
+    paragraph.appendChild(doc.createElement("br"));
+
+    if (onlyItem) {
+      list.replaceWith(paragraph);
+    } else {
+      let afterList = list.nextSibling;
+      while (afterList && afterList.nodeType === 3 && !afterList.textContent.trim()) {
+        afterList = afterList.nextSibling;
+      }
+      li.remove();
+      if (afterList && afterList.nodeName === "P") {
+        placeCaretAtStart(afterList);
+        return;
+      }
+      list.insertAdjacentElement("afterend", paragraph);
+    }
+
+    placeCaretAtStart(paragraph);
+  }
+
+  function placeCaretAtStart(el) {
+    if (!el) return;
+    const doc = el.ownerDocument || document;
+    const range = doc.createRange();
+    range.setStart(el, 0);
+    range.collapse(true);
+    const selection = doc.getSelection ? doc.getSelection() : window.getSelection();
+    if (!selection) return;
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  function isCaretAtStartOf(li, selection) {
+    if (!selection || selection.rangeCount === 0) return false;
+    const caretRange = selection.getRangeAt(0);
+    if (!caretRange.collapsed) return false;
+    const startRange = caretRange.cloneRange();
+    startRange.selectNodeContents(li);
+    startRange.collapse(true);
+    return caretRange.compareBoundaryPoints(Range.START_TO_START, startRange) === 0;
+  }
+
+  if (typeof window !== "undefined") {
+    window.installChecklistEnterExit = installChecklistEnterExit;
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1450,6 +1450,7 @@
   <script src="autosave.js"></script>
   <script src="./text-editor-checkboxes.js"></script>
   <script src="./editor-checkboxes.js"></script>
+  <script src="./checklist-fix.js"></script>
   <script src="./checklist-editor.js"></script>
   <script src="app.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- add a lightweight DOM helper that exits empty checklist list items before the browser inserts a new row
- hook the helper into the existing checklist editor and avoid double-handling when the event is already prevented
- load the helper on the main page so the behavior is available everywhere the editor runs

## Testing
- Not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e36aa257f083338ce0d409905c30d6