### PR TITLE
Add weekly/monthly summary navigation blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,6 +365,7 @@
       overflow:hidden;
       text-overflow:ellipsis;
     }
+    .day-nav-sub,
     .day-nav-today {
       font-size:.7rem;
       font-weight:500;
@@ -391,6 +392,66 @@
       display:flex;
       justify-content:flex-end;
       width:100%;
+    }
+
+    .daily-summary {
+      position:relative;
+      border:1px solid rgba(37,99,235,.18);
+      border-radius:1.5rem;
+      background:linear-gradient(135deg, rgba(37,99,235,.08), rgba(37,99,235,0));
+      overflow:hidden;
+    }
+    .daily-summary::before {
+      content:"";
+      position:absolute;
+      inset:0;
+      background:radial-gradient(circle at top left, rgba(99,102,241,.12), transparent 55%);
+      pointer-events:none;
+    }
+    .daily-summary__header {
+      position:relative;
+      display:flex;
+      flex-direction:column;
+      gap:.35rem;
+    }
+    .daily-summary__title {
+      font-size:1.25rem;
+      font-weight:700;
+      color:#0f172a;
+    }
+    .daily-summary__meta {
+      font-size:.95rem;
+      font-weight:600;
+      color:var(--accent-700);
+      letter-spacing:.04em;
+      text-transform:uppercase;
+    }
+    .daily-summary__body {
+      position:relative;
+      display:grid;
+      gap:.9rem;
+      color:#0f172a;
+      font-size:.95rem;
+    }
+    .daily-summary__text {
+      margin:0;
+      line-height:1.5;
+    }
+    .daily-summary__details {
+      margin:0;
+      padding-left:1.1rem;
+      font-size:.9rem;
+      color:#1f2937;
+    }
+    .daily-summary__details li {
+      margin-bottom:.25rem;
+    }
+    .daily-summary__hint {
+      margin:0;
+      font-size:.8rem;
+      color:var(--muted);
+      text-transform:uppercase;
+      letter-spacing:.08em;
     }
 
     /* Journalier — catégories */
@@ -506,6 +567,7 @@
       .day-nav-label {
         font-size:.85rem;
       }
+      .day-nav-sub,
       .day-nav-today {
         font-size:.65rem;
       }


### PR DESCRIPTION
## Summary
- add helper logic so weekly and monthly summaries appear as dedicated entries in the daily navigation flow
- render a dedicated summary card for week and month reviews with descriptive messaging and updated styling
- update navigation styling to support subtitles and highlight the inserted review blocks

## Testing
- node tests/weekDateRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3a1df3e00833397aafc041b5592e1