### PR TITLE
Enable interactive weekly and monthly summaries

### DIFF
--- a/app.js
+++ b/app.js
@@ -240,6 +240,7 @@
     }
   }
 
+  window.ensureRichTextModalCheckboxBehavior = ensureRichTextModalCheckboxBehavior;
   ensureRichTextModalCheckboxBehavior();
 
   const badgeManager = (() => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,12 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /u/{uid}/weekly_summaries/{weekKey}/answers/{consigneId} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+    match /u/{uid}/monthly_summaries/{monthKey}/answers/{consigneId} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
     // N'importe qui peut lire/écrire n'importe où
     match /{document=**} {
       allow read:  if true;

--- a/modes.js
+++ b/modes.js
@@ -5003,28 +5003,34 @@ function attachConsigneEditor(row, consigne, options = {}) {
   }
 }
 
+function hasValueForConsigne(consigne, value) {
+  const type = consigne?.type;
+  if (type === "long") {
+    return richTextHasContent(value);
+  }
+  if (type === "short") {
+    return typeof value === "string" && value.trim().length > 0;
+  }
+  if (type === "checklist") {
+    if (Array.isArray(value)) return value.some(Boolean);
+    if (value && typeof value === "object" && Array.isArray(value.items)) {
+      return value.items.some(Boolean);
+    }
+    return false;
+  }
+  if (type === "num") {
+    if (value === null || value === undefined || value === "") return false;
+    const num = Number(value);
+    return Number.isFinite(num);
+  }
+  return !(value === null || value === undefined || value === "");
+}
+
 function bindConsigneRowValue(row, consigne, { onChange, initialValue } = {}) {
   if (!row || !consigne) return;
-  const hasValueForConsigne = (value) => {
-    const type = consigne.type;
-    if (type === "long") {
-      return richTextHasContent(value);
-    }
-    if (type === "short") {
-      return typeof value === "string" && value.trim().length > 0;
-    }
-    if (type === "checklist") {
-      if (Array.isArray(value)) return value.some(Boolean);
-      if (value && typeof value === "object" && Array.isArray(value.items)) {
-        return value.items.some(Boolean);
-      }
-      return false;
-    }
-    return !(value === null || value === undefined || value === "");
-  };
   const mapValueForStatus = (value) => {
     if (row?.dataset?.skipAnswered === "1") {
-      if (hasValueForConsigne(value)) {
+      if (hasValueForConsigne(consigne, value)) {
         delete row.dataset.skipAnswered;
         return value;
       }
@@ -6531,6 +6537,8 @@ Modes.groupConsignes = groupConsignes;
 Modes.priorityTone = priorityTone;
 Modes.prioChip = prioChip;
 Modes.showToast = showToast;
+Modes.bindConsigneRowValue = bindConsigneRowValue;
+Modes.hasValueForConsigne = hasValueForConsigne;
 
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {


### PR DESCRIPTION
## Summary
- render weekly and monthly bilan rows with the same interactive consigne UI used for daily entries
- debounce and persist period answers automatically via new helpers that reuse Modes value detection
- expose the rich text setup hook globally and add Firestore rules/helpers for weekly and monthly summary answers

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3e31d94c48333b70c57bfc0c22076