### PR TITLE
Rendre les consignes du bilan interactives

### DIFF
--- a/bilan.js
+++ b/bilan.js
@@ -363,8 +363,10 @@
     row.innerHTML = `
       <div class="consigne-row__header">
         <div class="consigne-row__main">
-          <span class="consigne-row__title">${escapeHtml(consigne.text)}</span>
-          ${typeof Modes.prioChip === "function" ? Modes.prioChip(Number(consigne.priority) || 2) : ""}
+          <button type="button" class="consigne-row__toggle" data-consigne-open aria-haspopup="dialog">
+            <span class="consigne-row__title">${escapeHtml(consigne.text)}</span>
+            ${typeof Modes.prioChip === "function" ? Modes.prioChip(Number(consigne.priority) || 2) : ""}
+          </button>
         </div>
         <div class="consigne-row__meta">
           <span class="consigne-row__status" data-status="na">
@@ -413,6 +415,13 @@
           }
         },
       });
+    }
+    if (typeof Modes.attachConsigneEditor === "function") {
+      try {
+        Modes.attachConsigneEditor(row, consigne, options.editorConfig || {});
+      } catch (error) {
+        bilanLogger?.warn?.("bilan.attachConsigneEditor", error);
+      }
     }
     return row;
   }

--- a/modes.js
+++ b/modes.js
@@ -6538,6 +6538,7 @@ Modes.priorityTone = priorityTone;
 Modes.prioChip = prioChip;
 Modes.showToast = showToast;
 Modes.bindConsigneRowValue = bindConsigneRowValue;
+Modes.attachConsigneEditor = attachConsigneEditor;
 Modes.hasValueForConsigne = hasValueForConsigne;
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Summary
- rendre chaque consigne du bilan cliquable via le bouton standard afin d’ouvrir l’éditeur
- réutiliser l’éditeur existant de Modes pour les consignes de bilan en l’exposant au module

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4d378b14c83338d4aab0900eb9c98