### PR TITLE
Remove redundant meta labels from bilan consigne rows

### DIFF
--- a/bilan.js
+++ b/bilan.js
@@ -348,15 +348,7 @@
     } else {
       row.classList.add("consigne-row--parent");
     }
-    const metaParts = [];
-    if (consigne.summaryMeta?.subtitle) {
-      metaParts.push(consigne.summaryMeta.subtitle);
-    } else if (consigne.summaryCategory) {
-      metaParts.push(consigne.summaryCategory);
-    }
-    const metaHtml = metaParts.length
-      ? `<span class="consigne-row__meta-text text-xs text-[var(--muted)]">${escapeHtml(metaParts.join(" • "))}</span>`
-      : "";
+    const metaHtml = "";
     const descriptionHtml = consigne.summaryMeta?.description
       ? `<p class="consigne-row__description text-sm text-[var(--muted)]">${escapeHtml(consigne.summaryMeta.description)}</p>`
       : "";


### PR DESCRIPTION
## Summary
- remove the extra summary labels from bilan consigne headers so the layout matches the standard instructions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d6da0d6483339e76af9100da920b