### PR TITLE
Fix bilan sub-consigne handling

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -6539,6 +6539,7 @@ Modes.prioChip = prioChip;
 Modes.showToast = showToast;
 Modes.bindConsigneRowValue = bindConsigneRowValue;
 Modes.attachConsigneEditor = attachConsigneEditor;
+Modes.createHiddenConsigneRow = createHiddenConsigneRow;
 Modes.hasValueForConsigne = hasValueForConsigne;
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Summary
- ensure bilan summary renders sub-consignes within their parent cards and forwards them to the modal editor
- add helpers to reuse value serialization and resolve stored answers when wiring hidden child rows
- expose the existing hidden consigne row factory on the Modes namespace for reuse in the bilan view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ef5333a08333b172fe1060cfd3e7