### PR TITLE
Simplify bilan summaries and collapse categories

### DIFF
--- a/bilan.js
+++ b/bilan.js
@@ -631,17 +631,18 @@
       if (!category.flattened.length) {
         return;
       }
-      const group = document.createElement("section");
+      const group = document.createElement("details");
       group.className = "daily-category__group";
       group.dataset.category = category.label;
       if (family === "objective") {
         group.classList.add("daily-category__group--objective");
       }
-      const header = document.createElement("header");
+      const header = document.createElement("summary");
       header.className = "daily-category__group-header";
       header.innerHTML = `
         <h3 class="daily-category__group-title">${escapeHtml(category.label)}</h3>
         <span class="daily-category__group-count">${category.count} élément${category.count > 1 ? "s" : ""}</span>
+        <span class="daily-category__toggle" aria-hidden="true"></span>
       `;
       const groupItems = document.createElement("div");
       groupItems.className = "daily-category__group-items";
@@ -766,10 +767,6 @@
       mount.appendChild(empty);
       return;
     }
-    const autosaveInfo = document.createElement("p");
-    autosaveInfo.className = "text-xs text-[var(--muted)]";
-    autosaveInfo.textContent = "Chaque réponse est enregistrée automatiquement pour cette période.";
-    mount.appendChild(autosaveInfo);
     const grid = document.createElement("div");
     grid.className = "daily-grid";
     mount.appendChild(grid);

--- a/index.html
+++ b/index.html
@@ -752,8 +752,15 @@
     .daily-category__group-header {
       display:flex;
       align-items:center;
-      justify-content:space-between;
+      justify-content:flex-start;
       gap:.65rem;
+      cursor:pointer;
+      list-style:none;
+      padding:0;
+    }
+    .daily-category__group-header::-webkit-details-marker,
+    .daily-category__group-header::marker {
+      display:none;
     }
     .daily-category__group-title {
       margin:0;
@@ -768,6 +775,23 @@
       letter-spacing:.1em;
       font-weight:600;
       color:var(--muted);
+      margin-left:auto;
+    }
+    .daily-category__toggle {
+      flex:0 0 auto;
+      width:.75rem;
+      height:.75rem;
+      border-right:2px solid currentColor;
+      border-bottom:2px solid currentColor;
+      transform:rotate(-45deg);
+      transition:transform .2s ease, opacity .2s ease;
+      margin-left:.6rem;
+      opacity:.65;
+      color:rgba(15,23,42,.55);
+    }
+    .daily-category__group[open] .daily-category__toggle {
+      transform:rotate(45deg);
+      opacity:.9;
     }
     .daily-category__group-items {
       display:grid;
@@ -787,6 +811,9 @@
     .daily-category__group--objective .daily-category__group-count {
       color:rgba(30,64,175,.7);
     }
+    .daily-category__group--objective .daily-category__toggle {
+      color:rgba(30,64,175,.6);
+    }
     .daily-category--practice .daily-category__group {
       border-color:rgba(34,197,94,.24);
       background:rgba(240,253,244,.94);
@@ -801,6 +828,9 @@
     .daily-category--practice .daily-category__group-count {
       color:rgba(22,101,52,.66);
     }
+    .daily-category--practice .daily-category__toggle {
+      color:rgba(22,101,52,.55);
+    }
     .daily-category--daily .daily-category__group {
       border-color:rgba(14,165,233,.22);
       background:rgba(240,249,255,.94);
@@ -814,6 +844,9 @@
     }
     .daily-category--daily .daily-category__group-count {
       color:rgba(12,74,110,.62);
+    }
+    .daily-category--daily .daily-category__toggle {
+      color:rgba(12,74,110,.58);
     }
     .daily-category__low {
       margin-top:.2rem;

--- a/modes.js
+++ b/modes.js
@@ -5682,14 +5682,6 @@ function setBilanRuntimeSettings(settings) {
   return normalized;
 }
 
-function weekdayNameFromIndex(index) {
-  const normalized = normalizeWeekdayIndex(index);
-  const sample = new Date(Date.UTC(2023, 0, 1 + normalized));
-  const raw = DAILY_WEEKDAY_FORMATTER.format(sample) || "";
-  if (!raw) return "";
-  return raw.charAt(0).toUpperCase() + raw.slice(1);
-}
-
 async function loadBilanSettings(ctx) {
   const uid = ctx?.user?.uid;
   if (!uid || !ctx?.db || typeof Schema?.loadModuleSettings !== "function") {
@@ -5923,16 +5915,6 @@ function entryToQuery(entry, basePath, qp) {
   const search = params.toString();
   return `${basePath}${search ? `?${search}` : ""}`;
 }
-function buildSummaryHintText() {
-  const endName = weekdayNameFromIndex(DAILY_WEEK_ENDS_ON);
-  const nextName = weekdayNameFromIndex((DAILY_WEEK_ENDS_ON + 1) % 7);
-  if (!endName || !nextName) {
-    return "Les consignes s’affichent ici à la fin de chaque période pour garder le rythme des bilans.";
-  }
-  const endLower = endName.toLocaleLowerCase("fr-FR");
-  const nextLower = nextName.toLocaleLowerCase("fr-FR");
-  return `Les consignes s’affichent ici entre le ${endLower} de fin de semaine et le ${nextLower} suivant pour conserver le rythme “${endLower} → bilans → ${nextLower}”.`;
-}
 async function appendSummaryCard(container, entry, ctx) {
   if (!(container instanceof HTMLElement) || !entry) return;
   const card = document.createElement("section");
@@ -5949,24 +5931,15 @@ async function appendSummaryCard(container, entry, ctx) {
   if (!isMonthly && entry.weekStart && entry.weekEnd) {
     detailLines.push(`Du ${formatLongDateLabel(entry.weekStart)} au ${formatLongDateLabel(entry.weekEnd)}`);
   }
-  if (isMonthly && entry.weekStart && entry.weekEnd) {
-    detailLines.push(`Point d’ancrage : ${formatWeekRangeLabel(entry.weekStart, entry.weekEnd)}`);
-  }
-  const description = isMonthly
-    ? "Ce bloc regroupe l’ensemble des consignes actives du mois et fait le lien avec les objectifs mensuels ou annuels."
-    : "Ce bloc réunit les consignes de la semaine écoulée : journalier, pratique et objectifs hebdomadaires.";
-  const hintText = buildSummaryHintText();
   card.innerHTML = `
     <header class="daily-summary__header">
       <div class="daily-summary__title"><span class="daily-summary__icon" aria-hidden="true">${icon}</span><span>${escapeHtml(title)}</span></div>
       ${period ? `<div class="daily-summary__meta">${escapeHtml(period)}</div>` : ""}
     </header>
     <div class="daily-summary__body">
-      <p class="daily-summary__text">${escapeHtml(description)}</p>
       ${detailLines.length
         ? `<ul class="daily-summary__details">${detailLines.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>`
         : ""}
-      ${hintText ? `<p class="daily-summary__hint">${escapeHtml(hintText)}</p>` : ""}
       <div class="daily-summary__content space-y-4" data-bilan-root>
         <p class="text-sm text-[var(--muted)]">Chargement du bilan…</p>
       </div>


### PR DESCRIPTION
## Summary
- remove redundant helper text from weekly and monthly summary cards so only the period information remains
- render summary categories inside collapsed <details> elements with toggle indicators for a cleaner overview
- drop the autosave banner to minimize clutter around weekly and monthly bilan content

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e525df3a80833389288f221a34fc1e