### PR TITLE
Keep bilan categories expanded by default

### DIFF
--- a/bilan.js
+++ b/bilan.js
@@ -634,6 +634,9 @@
       const group = document.createElement("details");
       group.className = "daily-category__group";
       group.dataset.category = category.label;
+      if (family !== "practice") {
+        group.setAttribute("open", "");
+      }
       if (family === "objective") {
         group.classList.add("daily-category__group--objective");
       }


### PR DESCRIPTION
## Summary
- default bilan consigne category accordions to expanded state for all sections except practice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5313bff1083339a175f20cfabdb9b