### PR TITLE
Highlight bilan notes in consigne history

### DIFF
--- a/index.html
+++ b/index.html
@@ -1699,6 +1699,9 @@
     .history-panel__meta-row{ font-size:.75rem; color:#64748b; }
     .history-panel__meta{ display:inline-flex; align-items:center; gap:.25rem; background:rgba(148,163,184,0.16); padding:.25rem .55rem; border-radius:.75rem; }
     .history-panel__note{ margin:0; font-size:.85rem; color:#475569; line-height:1.45; word-break:break-word; }
+    .history-panel__note--bilan{ display:flex; flex-direction:column; gap:.35rem; }
+    .history-panel__note-badge{ display:inline-flex; align-items:center; gap:.25rem; padding:.2rem .6rem; border-radius:999px; background:rgba(59,130,246,0.12); color:#1d4ed8; font-size:.7rem; font-weight:600; letter-spacing:.01em; }
+    .history-panel__note-text{ display:block; }
     .history-panel__empty{ margin:0; padding:1rem; border-radius:.9rem; border:1px dashed rgba(148,163,184,0.45); background:#f8fafc; color:#64748b; font-size:.9rem; text-align:center; }
 
   </style>


### PR DESCRIPTION
## Summary
- detect notes originating from bilan answers when building the consigne history list
- add a dedicated badge and data attributes to tag bilan notes in the UI
- style the new badge so bilan notes stand out visually in the history panel

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e533247ac483339d3810476b662fa4