### PR TITLE
Fix clipping of consigne action menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@
       flex-direction:column;
       width:100%;
       box-sizing:border-box;
-      overflow:hidden;
+      overflow:visible;
     }
     .daily-category::before {
       content:"";


### PR DESCRIPTION
## Summary
- allow consigne action menus to render above the category card instead of being clipped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e548b1e8cc833397f061df86ea7354