### PR TITLE
Add summary actions menu and history visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1703,6 +1703,18 @@
     .history-panel__note-badge{ display:inline-flex; align-items:center; gap:.25rem; padding:.2rem .6rem; border-radius:999px; background:rgba(59,130,246,0.12); color:#1d4ed8; font-size:.7rem; font-weight:600; letter-spacing:.01em; }
     .history-panel__note-text{ display:block; }
     .history-panel__empty{ margin:0; padding:1rem; border-radius:.9rem; border:1px dashed rgba(148,163,184,0.45); background:#f8fafc; color:#64748b; font-size:.9rem; text-align:center; }
+    .history-panel__chart{ margin:0 0 1.25rem; padding:1.25rem; border-radius:1rem; border:1px solid rgba(148,163,184,0.2); background:linear-gradient(180deg, rgba(241,245,249,0.55), rgba(255,255,255,0.9)); box-shadow:0 12px 24px rgba(15,23,42,0.08); display:flex; flex-direction:column; gap:.75rem; }
+    .history-panel__chart-header{ display:flex; align-items:center; justify-content:space-between; gap:.5rem; flex-wrap:wrap; }
+    .history-panel__chart-title{ margin:0; font-size:1rem; font-weight:600; color:#0f172a; }
+    .history-panel__chart-count{ font-size:.8rem; font-weight:600; color:#2563eb; background:rgba(37,99,235,0.12); padding:.2rem .6rem; border-radius:999px; }
+    .history-panel__chart-values{ display:flex; align-items:center; justify-content:space-between; font-size:.75rem; color:#475569; text-transform:uppercase; letter-spacing:.08em; }
+    .history-panel__chart-figure{ margin:0; }
+    .history-panel__chart svg{ width:100%; height:auto; display:block; }
+    .history-panel__chart-axis{ display:flex; align-items:center; justify-content:space-between; font-size:.75rem; color:#475569; }
+    .history-panel__chart--empty{ align-items:center; justify-content:center; text-align:center; }
+    .history-panel__chart-empty-text{ margin:0; font-size:.85rem; color:#475569; }
+    .history-panel__item--summary{ border-color:rgba(59,130,246,0.25); background:linear-gradient(180deg, rgba(191,219,254,0.18), rgba(255,255,255,0.95)); }
+    .history-panel__summary-badge{ display:inline-flex; align-items:center; gap:.3rem; padding:.2rem .65rem; border-radius:.75rem; font-size:.75rem; font-weight:600; background:rgba(37,99,235,0.12); color:#1d4ed8; }
 
   </style>
 </head>


### PR DESCRIPTION
## Summary
- add the standard actions menu to weekly and monthly bilan cards so history remains accessible from the aggregated view
- enhance the history drawer to highlight bilan notes and display an inline chart of numeric responses over time for easier trend reading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e618ca622c8333aa0e00cb6e399ca7