### PR TITLE
Add Historique navigation tab to top-level menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -1766,6 +1766,7 @@
       admin: "#/admin",
       daily: "#/daily",
       practice: "#/practice",
+      history: "#/history",
       goals: "#/goals",
     };
     const activeTarget = map[alias] || "#/admin";

--- a/index.html
+++ b/index.html
@@ -220,6 +220,10 @@
     [data-section="practice"]{
       --accent-50:#F1FBF4; --accent-200:#D8F3E0; --accent-400:#BEE6C8; --accent-600:#8ED6A2; --accent-700:#63C582;
     }
+    /* Historique = bleu profond */
+    [data-section="history"]{
+      --accent-50:#ECF3FF; --accent-200:#C9DCFF; --accent-400:#93B8FF; --accent-600:#4A83FF; --accent-700:#2F5FE0;
+    }
     /* Objectifs = violet doux */
     [data-section="goals"]{
       --accent-50:#F7F3FF; --accent-200:#E9DFFF; --accent-400:#E3D0FF; --accent-600:#C7A7FF; --accent-700:#A884FF;
@@ -1743,6 +1747,7 @@
             <button class="tab" data-route="#/admin" data-nav="admin"><span>🛠️</span><span>Admin</span></button>
             <button class="tab" data-route="#/daily"><span>📅</span><span>Journalier</span></button>
             <button class="tab" data-route="#/practice"><span>⚡</span><span>Pratique</span></button>
+            <button class="tab" data-route="#/history"><span>🕑</span><span>Historique</span></button>
             <button class="tab" data-route="#/goals"><span>🎯</span><span>Objectifs</span></button>
           </nav>
           <div class="user-actions hidden absolute right-4 top-4 sm:static" id="user-actions" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add a dedicated accent palette for the Historique section
- expose the Historique route in the navigation tabs and keep routing in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6287f2e488333ae6c4b089c79be13