### PR TITLE
Expose numeric point helper for history panel

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -549,6 +549,22 @@ const LIKERT6_LABELS = {
 
 const NOTE_IGNORED_VALUES = new Set(["no_answer"]);
 
+function likert6NumericPoint(value) {
+  if (!value) return null;
+  const index = LIKERT6_ORDER.indexOf(String(value));
+  if (index === -1) return null;
+  return index;
+}
+
+function numericPoint(type, value) {
+  if (value === null || value === undefined || value === "") return null;
+  if (type === "likert6") {
+    return likert6NumericPoint(value);
+  }
+  const point = Schema.valueToNumericPoint(type, value);
+  return Number.isFinite(point) ? point : null;
+}
+
 function formatConsigneValue(type, value, options = {}) {
   const wantsHtml = options.mode === "html";
   if (type === "info") return "";
@@ -747,22 +763,6 @@ window.openCategoryDashboard = async function openCategoryDashboard(ctx, categor
     if (type === "short") return "Texte court";
     if (type === "info") return "";
     return "Libre";
-  }
-
-  function likert6NumericPoint(value) {
-    if (!value) return null;
-    const index = LIKERT6_ORDER.indexOf(String(value));
-    if (index === -1) return null;
-    return index;
-  }
-
-  function numericPoint(type, value) {
-    if (value === null || value === undefined || value === "") return null;
-    if (type === "likert6") {
-      return likert6NumericPoint(value);
-    }
-    const point = Schema.valueToNumericPoint(type, value);
-    return Number.isFinite(point) ? point : null;
   }
 
   function normalizeScore(type, value) {


### PR DESCRIPTION
## Summary
- hoist the Likert numeric helper functions so they are shared across modules
- allow the history view to compute numeric values without ReferenceErrors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e629ef62c48333870ba286a1b9be87