### PR TITLE
Add status-driven colors to history entries and charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1685,18 +1685,34 @@
     .history-panel__badge{ display:inline-flex; align-items:center; gap:.35rem; padding:.3rem .7rem; border-radius:.75rem; background:rgba(99,102,241,0.1); color:#4338ca; font-size:.75rem; font-weight:600; }
     .history-panel__body{ max-height:70vh; overflow:auto; padding-right:.25rem; }
     .history-panel__list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.75rem; }
-    .history-panel__item{ padding:.85rem .9rem; border:1px solid rgba(148,163,184,0.28); border-radius:1rem; background:#fff; display:flex; flex-direction:column; gap:.45rem; box-shadow:0 10px 20px rgba(15,23,42,0.1); }
+    .history-panel__item{ padding:.85rem .9rem; border:1px solid rgba(148,163,184,0.28); border-radius:1rem; background:#fff; display:flex; flex-direction:column; gap:.45rem; box-shadow:0 10px 20px rgba(15,23,42,0.1); transition:border-color .15s ease, background .15s ease, box-shadow .15s ease; }
+    .history-panel__item[data-status="ok-strong"]{ border-color:rgba(22,163,74,0.32); background:linear-gradient(180deg, rgba(134,239,172,0.18), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(22,163,74,0.15); }
+    .history-panel__item[data-status="ok-soft"]{ border-color:rgba(74,222,128,0.35); background:linear-gradient(180deg, rgba(187,247,208,0.18), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(74,222,128,0.16); }
+    .history-panel__item[data-status="mid"]{ border-color:rgba(234,179,8,0.32); background:linear-gradient(180deg, rgba(253,224,71,0.18), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(234,179,8,0.16); }
+    .history-panel__item[data-status="ko-soft"]{ border-color:rgba(248,113,113,0.3); background:linear-gradient(180deg, rgba(254,202,202,0.2), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(248,113,113,0.16); }
+    .history-panel__item[data-status="ko-strong"]{ border-color:rgba(220,38,38,0.32); background:linear-gradient(180deg, rgba(254,202,202,0.24), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(220,38,38,0.18); }
+    .history-panel__item[data-status="note"]{ border-color:rgba(59,130,246,0.28); background:linear-gradient(180deg, rgba(191,219,254,0.18), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(59,130,246,0.16); }
+    .history-panel__item[data-status="na"]{ border-color:rgba(148,163,184,0.32); background:linear-gradient(180deg, rgba(226,232,240,0.2), rgba(255,255,255,0.95)); box-shadow:0 12px 24px rgba(148,163,184,0.16); }
     .history-panel__item-row{ display:flex; align-items:flex-start; justify-content:space-between; gap:.75rem; flex-wrap:wrap; }
-    .history-panel__value{ display:flex; align-items:flex-start; gap:.55rem; font-size:1.05rem; font-weight:600; color:#0f172a; }
+    .history-panel__value{ display:flex; align-items:flex-start; gap:.55rem; font-size:1.05rem; font-weight:600; color:#0f172a; transition:color .15s ease; }
+    .history-panel__value[data-status="ok-strong"]{ color:#166534; }
+    .history-panel__value[data-status="ok-soft"]{ color:#15803d; }
+    .history-panel__value[data-status="mid"]{ color:#92400e; }
+    .history-panel__value[data-status="ko-soft"]{ color:#b91c1c; }
+    .history-panel__value[data-status="ko-strong"]{ color:#991b1b; }
+    .history-panel__value[data-status="note"]{ color:#1d4ed8; }
+    .history-panel__value[data-status="na"]{ color:#475569; }
     .history-panel__value span:last-child{ display:block; white-space:normal; word-break:break-word; overflow-wrap:break-word; }
     .history-panel__value span:last-child ul,
     .history-panel__value span:last-child ol{ margin:.35rem 0; padding-left:1.25rem; }
     .history-panel__value span:last-child li{ margin:.2rem 0; }
     .history-panel__value input[type="checkbox"]{ pointer-events:none; margin-right:.35rem; }
     .history-panel__dot{ width:.65rem; height:.65rem; border-radius:999px; background:#94a3b8; flex:none; }
-    .history-panel__dot--ok{ background:#16a34a; }
+    .history-panel__dot--ok-strong{ background:#16a34a; }
+    .history-panel__dot--ok-soft{ background:#4ade80; }
     .history-panel__dot--mid{ background:#eab308; }
-    .history-panel__dot--ko{ background:#dc2626; }
+    .history-panel__dot--ko-soft{ background:#f87171; }
+    .history-panel__dot--ko-strong{ background:#dc2626; }
     .history-panel__dot--note{ background:#3b82f6; }
     .history-panel__dot--na{ background:#94a3b8; }
     .history-panel__date{ font-size:.8rem; color:#475569; }
@@ -1708,9 +1724,23 @@
     .history-panel__note-text{ display:block; }
     .history-panel__empty{ margin:0; padding:1rem; border-radius:.9rem; border:1px dashed rgba(148,163,184,0.45); background:#f8fafc; color:#64748b; font-size:.9rem; text-align:center; }
     .history-panel__chart{ margin:0 0 1.25rem; padding:1.25rem; border-radius:1rem; border:1px solid rgba(148,163,184,0.2); background:linear-gradient(180deg, rgba(241,245,249,0.55), rgba(255,255,255,0.9)); box-shadow:0 12px 24px rgba(15,23,42,0.08); display:flex; flex-direction:column; gap:.75rem; }
+    .history-panel__chart[data-average-status="ok-strong"]{ border-color:rgba(22,163,74,0.32); box-shadow:0 14px 28px rgba(22,163,74,0.14); }
+    .history-panel__chart[data-average-status="ok-soft"]{ border-color:rgba(74,222,128,0.3); box-shadow:0 14px 28px rgba(74,222,128,0.14); }
+    .history-panel__chart[data-average-status="mid"]{ border-color:rgba(234,179,8,0.3); box-shadow:0 14px 28px rgba(234,179,8,0.14); }
+    .history-panel__chart[data-average-status="ko-soft"]{ border-color:rgba(248,113,113,0.3); box-shadow:0 14px 28px rgba(248,113,113,0.14); }
+    .history-panel__chart[data-average-status="ko-strong"]{ border-color:rgba(220,38,38,0.32); box-shadow:0 14px 28px rgba(220,38,38,0.16); }
+    .history-panel__chart[data-average-status="note"]{ border-color:rgba(59,130,246,0.28); box-shadow:0 14px 28px rgba(59,130,246,0.14); }
+    .history-panel__chart[data-average-status="na"]{ border-color:rgba(148,163,184,0.3); box-shadow:0 14px 28px rgba(148,163,184,0.14); }
     .history-panel__chart-header{ display:flex; align-items:center; justify-content:space-between; gap:.5rem; flex-wrap:wrap; }
     .history-panel__chart-title{ margin:0; font-size:1rem; font-weight:600; color:#0f172a; }
-    .history-panel__chart-count{ font-size:.8rem; font-weight:600; color:#2563eb; background:rgba(37,99,235,0.12); padding:.2rem .6rem; border-radius:999px; }
+    .history-panel__chart-count{ font-size:.8rem; font-weight:600; color:#2563eb; background:rgba(37,99,235,0.12); padding:.2rem .6rem; border-radius:999px; transition:color .15s ease, background .15s ease; }
+    .history-panel__chart[data-average-status="ok-strong"] .history-panel__chart-count{ color:#166534; background:rgba(22,163,74,0.12); }
+    .history-panel__chart[data-average-status="ok-soft"] .history-panel__chart-count{ color:#15803d; background:rgba(74,222,128,0.16); }
+    .history-panel__chart[data-average-status="mid"] .history-panel__chart-count{ color:#92400e; background:rgba(234,179,8,0.16); }
+    .history-panel__chart[data-average-status="ko-soft"] .history-panel__chart-count{ color:#b91c1c; background:rgba(248,113,113,0.16); }
+    .history-panel__chart[data-average-status="ko-strong"] .history-panel__chart-count{ color:#991b1b; background:rgba(220,38,38,0.16); }
+    .history-panel__chart[data-average-status="note"] .history-panel__chart-count{ color:#1d4ed8; background:rgba(59,130,246,0.16); }
+    .history-panel__chart[data-average-status="na"] .history-panel__chart-count{ color:#475569; background:rgba(148,163,184,0.16); }
     .history-panel__chart-values{ display:flex; align-items:center; justify-content:space-between; font-size:.75rem; color:#475569; text-transform:uppercase; letter-spacing:.08em; }
     .history-panel__chart-figure{ margin:0; }
     .history-panel__chart svg{ width:100%; height:auto; display:block; }


### PR DESCRIPTION
## Summary
- add consistent status color mappings for history entries and expose them to the DOM
- tint history list items and chart styling according to each response status and the average trend

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62e74dca08333a02eb380aafd68c8