### PR TITLE
Remove history tab from main navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1777,7 +1777,6 @@
             <button class="tab" data-route="#/admin" data-nav="admin"><span>🛠️</span><span>Admin</span></button>
             <button class="tab" data-route="#/daily"><span>📅</span><span>Journalier</span></button>
             <button class="tab" data-route="#/practice"><span>⚡</span><span>Pratique</span></button>
-            <button class="tab" data-route="#/history"><span>🕑</span><span>Historique</span></button>
             <button class="tab" data-route="#/goals"><span>🎯</span><span>Objectifs</span></button>
           </nav>
           <div class="user-actions hidden absolute right-4 top-4 sm:static" id="user-actions" aria-hidden="true">


### PR DESCRIPTION
## Summary
- remove the history tab button from the top navigation so only the other routes remain visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63261537083338f611da7245a6106