### PR TITLE
Add range filter selector to history charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1682,6 +1682,10 @@
     .history-panel__heading{ margin:0; font-size:1.2rem; font-weight:600; color:#0f172a; }
     .history-panel__subtitle{ margin:0; font-size:.85rem; color:#475569; }
     .history-panel__actions{ display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; }
+    .history-panel__range{ display:flex; align-items:center; gap:.45rem; padding:.2rem .6rem; border-radius:.75rem; background:rgba(148,163,184,0.12); font-size:.75rem; color:#475569; font-weight:500; }
+    .history-panel__range span{ font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; }
+    .history-panel__range select{ appearance:none; -webkit-appearance:none; -moz-appearance:none; border:1px solid rgba(148,163,184,0.55); border-radius:.6rem; background:#fff; padding:.25rem .9rem .25rem .5rem; font-size:.8rem; color:#0f172a; box-shadow:0 1px 2px rgba(15,23,42,0.08); }
+    .history-panel__range select:focus{ outline:2px solid rgba(37,99,235,0.35); outline-offset:2px; border-color:rgba(37,99,235,0.55); }
     .history-panel__badge{ display:inline-flex; align-items:center; gap:.35rem; padding:.3rem .7rem; border-radius:.75rem; background:rgba(99,102,241,0.1); color:#4338ca; font-size:.75rem; font-weight:600; }
     .history-panel__body{ max-height:70vh; overflow:auto; padding-right:.25rem; }
     .history-panel__list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.75rem; }


### PR DESCRIPTION
## Summary
- add presets to filter history chart data by recent iterations or time windows
- style and render a range selector in the history panel actions bar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6340faec4833382f71285edce7dfd