### PR TITLE
Prevent overlap of history axis labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1242,7 +1242,7 @@
     .practice-dashboard__history-value li{ margin:.2rem 0; }
     .practice-dashboard__history-value input[type="checkbox"]{ pointer-events:none; margin-right:.35rem; }
     .practice-dashboard__history-note{ font-size:.85rem; color:#475569; line-height:1.4; word-break:break-word; }
-    .practice-dashboard__history-date{ display:flex; flex-direction:column; align-items:flex-end; gap:.25rem; font-size:.78rem; color:#64748b; white-space:nowrap; }
+    .practice-dashboard__history-date{ display:flex; flex-direction:column; align-items:flex-end; gap:.25rem; font-size:.78rem; color:#64748b; text-align:right; white-space:normal; line-height:1.25; overflow-wrap:break-word; }
     .practice-dashboard__history-date-main{ font-weight:600; color:#0f172a; }
     .practice-dashboard__history-date-sub{ font-size:.75rem; color:#94a3b8; }
     .practice-dashboard__history-meta-row{ font-size:.75rem; color:#64748b; }


### PR DESCRIPTION
## Summary
- allow practice history date labels to wrap and align right
- reduce the chance of timestamp overlaps on the horizontal axis

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e63e8f344c8333bed1ccc08642efe2