### PR TITLE
Align history charts with fixed calendar ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -1763,6 +1763,8 @@
     .history-panel__chart-axis-marker--day .history-panel__chart-axis-label{ color:#475569; opacity:.7; font-size:.65rem; }
     .history-panel__chart-axis-marker--data .history-panel__chart-axis-tick{ height:.85rem; background:#2563eb; }
     .history-panel__chart-axis-marker--data .history-panel__chart-axis-label{ color:#2563eb; font-weight:600; }
+    .history-panel__chart-axis-marker--boundary .history-panel__chart-axis-tick{ height:.75rem; background:rgba(15,23,42,0.35); }
+    .history-panel__chart-axis-marker--boundary .history-panel__chart-axis-label{ color:#0f172a; font-weight:600; }
     .history-panel__chart--empty{ align-items:center; justify-content:center; text-align:center; }
     .history-panel__chart-empty-text{ margin:0; font-size:.85rem; color:#475569; }
     .history-panel__item--summary{ border-color:rgba(59,130,246,0.25); background:linear-gradient(180deg, rgba(191,219,254,0.18), rgba(255,255,255,0.95)); }


### PR DESCRIPTION
## Summary
- align the history chart ranges with full calendar weeks, months, and years based on the latest answer dates
- inject calendar-aware axis markers and gridlines so empty periods remain visible across the selected range
- add styling for the new boundary markers used to highlight the start and end of the visible period

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e648c4807c8333a97f8cecbbae6445