### PR TITLE
Add navigation arrows to history charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1686,6 +1686,13 @@
     .history-panel__range span{ font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; }
     .history-panel__range select{ appearance:none; -webkit-appearance:none; -moz-appearance:none; border:1px solid rgba(148,163,184,0.55); border-radius:.6rem; background:#fff; padding:.25rem .9rem .25rem .5rem; font-size:.8rem; color:#0f172a; box-shadow:0 1px 2px rgba(15,23,42,0.08); }
     .history-panel__range select:focus{ outline:2px solid rgba(37,99,235,0.35); outline-offset:2px; border-color:rgba(37,99,235,0.55); }
+    .history-panel__nav{ display:flex; align-items:center; gap:.35rem; padding:.2rem .5rem; border-radius:.75rem; background:rgba(148,163,184,0.12); font-size:.75rem; color:#475569; font-weight:500; }
+    .history-panel__nav[hidden]{ display:none; }
+    .history-panel__nav-btn{ width:1.75rem; height:1.75rem; display:inline-flex; align-items:center; justify-content:center; border-radius:999px; border:1px solid rgba(148,163,184,0.5); background:#fff; color:#475569; font-size:1rem; line-height:1; box-shadow:0 1px 2px rgba(15,23,42,0.08); transition:background .15s ease, color .15s ease, border-color .15s ease; }
+    .history-panel__nav-btn:hover:not(:disabled){ background:rgba(99,102,241,0.1); color:#3730a3; border-color:rgba(99,102,241,0.4); }
+    .history-panel__nav-btn:focus-visible{ outline:2px solid rgba(37,99,235,0.35); outline-offset:2px; }
+    .history-panel__nav-btn:disabled{ opacity:0.4; cursor:not-allowed; }
+    .history-panel__nav-label{ white-space:nowrap; }
     .history-panel__badge{ display:inline-flex; align-items:center; gap:.35rem; padding:.3rem .7rem; border-radius:.75rem; background:rgba(99,102,241,0.1); color:#4338ca; font-size:.75rem; font-weight:600; }
     .history-panel__body{ max-height:70vh; overflow:auto; padding-right:.25rem; }
     .history-panel__list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.75rem; }


### PR DESCRIPTION
## Summary
- add week/month/year navigation bounds and offset handling to history chart rendering
- expose previous/next controls with contextual labels in the history drawer
- style the new navigation buttons alongside the existing range selector

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e656d8b1cc8333adf9deee0f9e4614