### PR TITLE
Limit history charts to boundary axis labels

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -5393,17 +5393,14 @@ function renderHistoryChart(data, { type } = {}) {
       const lastDayOfYear = new Date(axisEnd.getTime() - dayMs);
       addMarker(axisStart, "boundary", 4, boundaryLabelFormatter);
       addMarker(lastDayOfYear, "boundary", 4, boundaryLabelFormatter);
-      addMonthlyMarkers();
     } else if (axisMode === "month") {
       const monthEnd = new Date(axisEnd.getTime() - dayMs);
       addMarker(axisStart, "boundary", 4, boundaryLabelFormatter);
       addMarker(monthEnd, "boundary", 4, boundaryLabelFormatter);
-      addWeeklyMarkers();
     } else if (axisMode === "week") {
       const weekEnd = new Date(axisEnd.getTime() - dayMs);
       addMarker(axisStart, "boundary", 4, boundaryLabelFormatter);
       addMarker(weekEnd, "boundary", 4, boundaryLabelFormatter);
-      addDailyMarkers();
     } else {
       addMarker(axisStart, "boundary", 3, boundaryLabelFormatter);
       addMarker(axisEnd, "boundary", 3, boundaryLabelFormatter);


### PR DESCRIPTION
## Summary
- remove intermediate weekly, monthly, and daily markers from history chart axes
- keep only boundary labels to improve readability on week, month, and year views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6650faaac83338f50a1ac19f47adb