### PR TITLE
Simplify history chart iteration axis labels

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -5319,7 +5319,7 @@ function renderHistoryChart(data, { type } = {}) {
       const numberFormatter = new Intl.NumberFormat("fr-FR");
       uniqueIndexes.forEach((index) => {
         const ratio = totalPoints === 1 ? 0.5 : index / denominator;
-        const label = `Itération ${numberFormatter.format(index + 1)}`;
+        const label = numberFormatter.format(index + 1);
         axisMarkers.push({
           type: "iteration",
           ratio,


### PR DESCRIPTION
## Summary
- remove the "Itération" prefix from iteration axis labels in the history chart so ticks take less horizontal space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66a3e2f14833384179fdde3df4a26