### PR TITLE
Refine consigne history chart labels and Likert axis

### DIFF
--- a/index.html
+++ b/index.html
@@ -1753,9 +1753,16 @@
     .history-panel__chart[data-average-status="note"] .history-panel__chart-count{ color:#1d4ed8; background:rgba(59,130,246,0.16); }
     .history-panel__chart[data-average-status="na"] .history-panel__chart-count{ color:#475569; background:rgba(148,163,184,0.16); }
     .history-panel__chart-values{ display:flex; align-items:center; justify-content:space-between; font-size:.75rem; color:#475569; text-transform:uppercase; letter-spacing:.08em; }
-    .history-panel__chart-figure{ margin:0; }
+    .history-panel__chart-figure{ margin:0; position:relative; }
+    .history-panel__chart-figure--with-scale{ display:flex; }
+    .history-panel__chart-scale{ display:flex; flex-direction:column; justify-content:space-between; width:3.75rem; padding:28px 0; margin-right:.75rem; font-size:.72rem; color:#475569; text-transform:none; letter-spacing:0; }
+    .history-panel__chart-scale-label{ position:relative; padding-right:.75rem; text-align:right; font-weight:600; }
+    .history-panel__chart-scale-label::after{ content:""; position:absolute; right:0; top:50%; width:.75rem; height:1px; background:rgba(148,163,184,0.45); transform:translateY(-50%); }
+    .history-panel__chart-canvas{ flex:1; }
+    .history-panel__chart-figure--with-scale svg{ width:100%; }
     .history-panel__chart svg{ width:100%; height:auto; display:block; }
     .history-panel__chart-axis{ position:relative; min-height:3rem; padding-top:.75rem; font-size:.7rem; color:#475569; }
+    .history-panel__chart-axis[data-has-scale]{ margin-left:4.5rem; }
     .history-panel__chart-axis-track{ position:absolute; left:0; right:0; bottom:.85rem; height:1px; background:rgba(148,163,184,0.35); }
     .history-panel__chart-axis-marker{ position:absolute; bottom:.2rem; display:flex; flex-direction:column; align-items:center; gap:.25rem; transform:translateX(-50%); pointer-events:none; text-transform:uppercase; letter-spacing:.08em; max-width:min(6.5rem,30vw); }
     .history-panel__chart-axis-marker--start{ transform:translateX(0); align-items:flex-start; }


### PR DESCRIPTION
## Summary
- rename the history chart heading to focus on recorded answers instead of trend wording
- ensure Likert history charts always use the full Non→Oui range and display labelled axis ticks
- update the chart layout styles to show the new Likert vertical scale alongside the plot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67984e8308333a4d4a4b665b289ae