### PR TITLE
Fix Firestore collection path for daily history query

### DIFF
--- a/modes.js
+++ b/modes.js
@@ -5906,7 +5906,7 @@ async function openHistory(ctx, consigne, options = {}) {
   let ss;
   try {
     const qy = modesFirestore.query(
-      modesFirestore.collection(ctx.db, `u/${uid}/responses`),
+      modesFirestore.collection(ctx.db, uid, "responses"),
       modesFirestore.where("consigneId", "==", consigneId),
       modesFirestore.orderBy("createdAt", "desc"),
       modesFirestore.limit(60)


### PR DESCRIPTION
## Summary
- query daily consigne history from the same Firestore collection path used when saving responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6901100888333a8cff2c092d5ca59